### PR TITLE
compiler: add no_frontend mode and gate experimental IR-binary flow

### DIFF
--- a/std/compiler/backend_vm.go
+++ b/std/compiler/backend_vm.go
@@ -1,3 +1,5 @@
+//go:build !no_backend_vm
+
 package main
 
 import (

--- a/std/compiler/backend_vm_stub.go
+++ b/std/compiler/backend_vm_stub.go
@@ -1,0 +1,11 @@
+//go:build no_backend_vm
+
+package main
+
+import "fmt"
+
+var vmExitCode int
+
+func generateVM(irmod *IRModule, outputPath string) error {
+	return fmt.Errorf("vm backend disabled (built with no_backend_vm tag)")
+}

--- a/std/compiler/ir_binary_codec.go
+++ b/std/compiler/ir_binary_codec.go
@@ -1,0 +1,682 @@
+//go:build exp_ir_binary
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+var irBinaryMagic = []byte{'R', 'T', 'G', 'I', 'R', 'B', '1', 0}
+
+type irBinWriter struct {
+	buf []byte
+}
+
+func (w *irBinWriter) bytes() []byte {
+	return w.buf
+}
+
+func (w *irBinWriter) writeByte(v byte) {
+	w.buf = append(w.buf, v)
+}
+
+func (w *irBinWriter) writeBool(v bool) {
+	if v {
+		w.writeByte(1)
+	} else {
+		w.writeByte(0)
+	}
+}
+
+func (w *irBinWriter) writeU32(v uint32) {
+	u := int(v)
+	b0 := byte(u % 256)
+	u = u / 256
+	b1 := byte(u % 256)
+	u = u / 256
+	b2 := byte(u % 256)
+	u = u / 256
+	b3 := byte(u % 256)
+	w.buf = append(w.buf, b0, b1, b2, b3)
+}
+
+func (w *irBinWriter) writeI64(v int64) {
+	u := uint64(v)
+	w.buf = append(w.buf, byte(u), byte(u>>8), byte(u>>16), byte(u>>24),
+		byte(u>>32), byte(u>>40), byte(u>>48), byte(u>>56))
+}
+
+func (w *irBinWriter) writeInt(v int) {
+	w.writeI64(int64(v))
+}
+
+func (w *irBinWriter) writeString(s string) {
+	w.writeU32(uint32(len(s)))
+	w.buf = append(w.buf, []byte(s)...)
+}
+
+type irBinReader struct {
+	data []byte
+	off  int
+}
+
+func (r *irBinReader) need(n int) error {
+	if r.off+n > len(r.data) {
+		return fmt.Errorf("truncated IR binary")
+	}
+	return nil
+}
+
+func (r *irBinReader) readByte() (byte, error) {
+	if err := r.need(1); err != nil {
+		return 0, err
+	}
+	v := r.data[r.off]
+	r.off++
+	return v, nil
+}
+
+func (r *irBinReader) readBool() (bool, error) {
+	b, err := r.readByte()
+	if err != nil {
+		return false, err
+	}
+	if b == 0 {
+		return false, nil
+	}
+	if b == 1 {
+		return true, nil
+	}
+	return false, fmt.Errorf("invalid bool value %d", int(b))
+}
+
+func (r *irBinReader) readU32() (uint32, error) {
+	if err := r.need(4); err != nil {
+		return 0, err
+	}
+	b := r.data[r.off : r.off+4]
+	r.off += 4
+	v := uint32(b[0]) + uint32(b[1])*256 + uint32(b[2])*65536 + uint32(b[3])*16777216
+	return v, nil
+}
+
+func (r *irBinReader) readI64() (int64, error) {
+	if err := r.need(8); err != nil {
+		return 0, err
+	}
+	b := r.data[r.off : r.off+8]
+	r.off += 8
+	u := uint64(b[0]) |
+		(uint64(b[1]) << 8) |
+		(uint64(b[2]) << 16) |
+		(uint64(b[3]) << 24) |
+		(uint64(b[4]) << 32) |
+		(uint64(b[5]) << 40) |
+		(uint64(b[6]) << 48) |
+		(uint64(b[7]) << 56)
+	return int64(u), nil
+}
+
+func (r *irBinReader) readInt() (int, error) {
+	v, err := r.readI64()
+	if err != nil {
+		return 0, err
+	}
+	return int(v), nil
+}
+
+func (r *irBinReader) readString() (string, error) {
+	n, err := r.readU32()
+	if err != nil {
+		return "", err
+	}
+	if err := r.need(int(n)); err != nil {
+		return "", err
+	}
+	s := string(r.data[r.off : r.off+int(n)])
+	r.off += int(n)
+	return s, nil
+}
+
+func typeIndex(idx map[*TypeInfo]int, t *TypeInfo) int {
+	if t == nil {
+		return -1
+	}
+	return idx[t]
+}
+
+func collectTypeInfo(t *TypeInfo, idx map[*TypeInfo]int, all *[]*TypeInfo) {
+	if t == nil {
+		return
+	}
+	if _, ok := idx[t]; ok {
+		return
+	}
+	idx[t] = len(*all)
+	*all = append(*all, t)
+	collectTypeInfo(t.Elem, idx, all)
+	collectTypeInfo(t.Key, idx, all)
+	for _, f := range t.Fields {
+		collectTypeInfo(f.Type, idx, all)
+	}
+	for _, p := range t.Params {
+		collectTypeInfo(p, idx, all)
+	}
+	for _, r := range t.Results {
+		collectTypeInfo(r, idx, all)
+	}
+}
+
+func writeIRBinary(irmod *IRModule, path string) error {
+	if irmod == nil {
+		return fmt.Errorf("nil IR module")
+	}
+
+	typeIdx := make(map[*TypeInfo]int)
+	var allTypes []*TypeInfo
+	for _, t := range irmod.Types {
+		collectTypeInfo(t, typeIdx, &allTypes)
+	}
+	for i := 0; i < len(irmod.Globals); i++ {
+		collectTypeInfo(irmod.Globals[i].Type, typeIdx, &allTypes)
+	}
+	for _, f := range irmod.Funcs {
+		for i := 0; i < len(f.Locals); i++ {
+			collectTypeInfo(f.Locals[i].Type, typeIdx, &allTypes)
+		}
+	}
+
+	w := &irBinWriter{}
+	for i := 0; i < len(irBinaryMagic); i++ {
+		w.writeByte(irBinaryMagic[i])
+	}
+
+	w.writeU32(uint32(len(allTypes)))
+	for i := 0; i < len(allTypes); i++ {
+		t := allTypes[i]
+		w.writeInt(int(t.Kind))
+		w.writeString(t.Name)
+		w.writeString(t.Pkg)
+		w.writeInt(t.Size)
+		w.writeInt(t.Align)
+		w.writeInt(typeIndex(typeIdx, t.Elem))
+		w.writeInt(typeIndex(typeIdx, t.Key))
+
+		w.writeU32(uint32(len(t.Fields)))
+		for j := 0; j < len(t.Fields); j++ {
+			f := t.Fields[j]
+			w.writeString(f.Name)
+			w.writeInt(typeIndex(typeIdx, f.Type))
+			w.writeInt(f.Offset)
+		}
+
+		w.writeU32(uint32(len(t.Params)))
+		for j := 0; j < len(t.Params); j++ {
+			w.writeInt(typeIndex(typeIdx, t.Params[j]))
+		}
+
+		w.writeU32(uint32(len(t.Results)))
+		for j := 0; j < len(t.Results); j++ {
+			w.writeInt(typeIndex(typeIdx, t.Results[j]))
+		}
+	}
+
+	w.writeU32(uint32(len(irmod.Types)))
+	for i := 0; i < len(irmod.Types); i++ {
+		w.writeInt(typeIndex(typeIdx, irmod.Types[i]))
+	}
+
+	w.writeU32(uint32(len(irmod.Globals)))
+	for i := 0; i < len(irmod.Globals); i++ {
+		g := irmod.Globals[i]
+		w.writeString(g.Name)
+		w.writeInt(typeIndex(typeIdx, g.Type))
+		w.writeInt(g.Index)
+	}
+
+	w.writeU32(uint32(len(irmod.Funcs)))
+	for i := 0; i < len(irmod.Funcs); i++ {
+		f := irmod.Funcs[i]
+		w.writeString(f.Name)
+		w.writeInt(f.Params)
+		w.writeInt(f.RetCount)
+
+		w.writeU32(uint32(len(f.Locals)))
+		for j := 0; j < len(f.Locals); j++ {
+			l := f.Locals[j]
+			w.writeString(l.Name)
+			w.writeInt(typeIndex(typeIdx, l.Type))
+			w.writeInt(l.Index)
+			w.writeBool(l.Is64)
+			w.writeInt(l.Width)
+		}
+
+		w.writeU32(uint32(len(f.Code)))
+		for j := 0; j < len(f.Code); j++ {
+			in := f.Code[j]
+			w.writeInt(int(in.Op))
+			w.writeInt(in.Arg)
+			w.writeInt(in.Width)
+			w.writeI64(in.Val)
+			w.writeString(in.Name)
+		}
+	}
+
+	w.writeU32(uint32(len(irmod.TypeIDs)))
+	for k := range irmod.TypeIDs {
+		w.writeString(k)
+		w.writeInt(irmod.TypeIDs[k])
+	}
+
+	w.writeU32(uint32(len(irmod.MethodTable)))
+	for k := range irmod.MethodTable {
+		w.writeString(k)
+		w.writeString(irmod.MethodTable[k])
+	}
+
+	w.writeU32(uint32(len(irmod.IfaceMethods)))
+	for k := range irmod.IfaceMethods {
+		ms := irmod.IfaceMethods[k]
+		w.writeString(k)
+		w.writeU32(uint32(len(ms)))
+		for j := 0; j < len(ms); j++ {
+			w.writeString(ms[j])
+		}
+	}
+
+	w.writeU32(uint32(len(irmod.IfaceMethodRets)))
+	for k := range irmod.IfaceMethodRets {
+		w.writeString(k)
+		w.writeInt(irmod.IfaceMethodRets[k])
+	}
+
+	return os.WriteFile(path, w.bytes(), 0644)
+}
+
+func readIRMagic(r *irBinReader) error {
+	for i := 0; i < len(irBinaryMagic); i++ {
+		b, err := r.readByte()
+		if err != nil {
+			return err
+		}
+		if b != irBinaryMagic[i] {
+			return fmt.Errorf("invalid IR binary magic")
+		}
+	}
+	return nil
+}
+
+func readIRTypes(r *irBinReader) ([]*TypeInfo, error) {
+	typeCountU32, err := r.readU32()
+	if err != nil {
+		return nil, err
+	}
+	typeCount := int(typeCountU32)
+	types := make([]*TypeInfo, typeCount)
+	for i := 0; i < typeCount; i++ {
+		types[i] = &TypeInfo{}
+	}
+	for i := 0; i < typeCount; i++ {
+		t := types[i]
+		kind, err := r.readInt()
+		if err != nil {
+			return nil, err
+		}
+		t.Kind = TypeKind(kind)
+		t.Name, err = r.readString()
+		if err != nil {
+			return nil, err
+		}
+		t.Pkg, err = r.readString()
+		if err != nil {
+			return nil, err
+		}
+		t.Size, err = r.readInt()
+		if err != nil {
+			return nil, err
+		}
+		t.Align, err = r.readInt()
+		if err != nil {
+			return nil, err
+		}
+		elemIdx, err := r.readInt()
+		if err != nil {
+			return nil, err
+		}
+		keyIdx, err := r.readInt()
+		if err != nil {
+			return nil, err
+		}
+		if elemIdx >= 0 && elemIdx < len(types) {
+			t.Elem = types[elemIdx]
+		}
+		if keyIdx >= 0 && keyIdx < len(types) {
+			t.Key = types[keyIdx]
+		}
+		fieldCountU32, err := r.readU32()
+		if err != nil {
+			return nil, err
+		}
+		fieldCount := int(fieldCountU32)
+		fields := make([]FieldInfo, 0, fieldCount)
+		for j := 0; j < fieldCount; j++ {
+			var f FieldInfo
+			name, err := r.readString()
+			if err != nil {
+				return nil, err
+			}
+			typeIdx, err := r.readInt()
+			if err != nil {
+				return nil, err
+			}
+			offset, err := r.readInt()
+			if err != nil {
+				return nil, err
+			}
+			f.Name = name
+			f.Offset = offset
+			if typeIdx >= 0 && typeIdx < len(types) {
+				f.Type = types[typeIdx]
+			}
+			fields = append(fields, f)
+		}
+		t.Fields = fields
+		paramCountU32, err := r.readU32()
+		if err != nil {
+			return nil, err
+		}
+		paramCount := int(paramCountU32)
+		params := make([]*TypeInfo, 0, paramCount)
+		for j := 0; j < paramCount; j++ {
+			typeIdx, err := r.readInt()
+			if err != nil {
+				return nil, err
+			}
+			var p *TypeInfo
+			if typeIdx >= 0 && typeIdx < len(types) {
+				p = types[typeIdx]
+			}
+			params = append(params, p)
+		}
+		t.Params = params
+		resultCountU32, err := r.readU32()
+		if err != nil {
+			return nil, err
+		}
+		resultCount := int(resultCountU32)
+		results := make([]*TypeInfo, 0, resultCount)
+		for j := 0; j < resultCount; j++ {
+			typeIdx, err := r.readInt()
+			if err != nil {
+				return nil, err
+			}
+			var res *TypeInfo
+			if typeIdx >= 0 && typeIdx < len(types) {
+				res = types[typeIdx]
+			}
+			results = append(results, res)
+		}
+		t.Results = results
+	}
+	return types, nil
+}
+
+func readIRRootTypes(r *irBinReader, types []*TypeInfo) ([]*TypeInfo, error) {
+	countU32, err := r.readU32()
+	if err != nil {
+		return nil, err
+	}
+	count := int(countU32)
+	rootTypes := make([]*TypeInfo, count)
+	for i := 0; i < count; i++ {
+		idx, err := r.readInt()
+		if err != nil {
+			return nil, err
+		}
+		if idx >= 0 && idx < len(types) {
+			rootTypes[i] = types[idx]
+		}
+	}
+	return rootTypes, nil
+}
+
+func readIRGlobals(r *irBinReader, types []*TypeInfo) ([]IRGlobal, error) {
+	countU32, err := r.readU32()
+	if err != nil {
+		return nil, err
+	}
+	count := int(countU32)
+	globals := make([]IRGlobal, 0, count)
+	for i := 0; i < count; i++ {
+		var g IRGlobal
+		g.Name, err = r.readString()
+		if err != nil {
+			return nil, err
+		}
+		typeIdx, err := r.readInt()
+		if err != nil {
+			return nil, err
+		}
+		if typeIdx >= 0 && typeIdx < len(types) {
+			g.Type = types[typeIdx]
+		}
+		g.Index, err = r.readInt()
+		if err != nil {
+			return nil, err
+		}
+		globals = append(globals, g)
+	}
+	return globals, nil
+}
+
+func readIRFuncs(r *irBinReader, types []*TypeInfo) ([]*IRFunc, error) {
+	countU32, err := r.readU32()
+	if err != nil {
+		return nil, err
+	}
+	count := int(countU32)
+	funcs := make([]*IRFunc, 0, count)
+	for i := 0; i < count; i++ {
+		f := &IRFunc{}
+		f.Name, err = r.readString()
+		if err != nil {
+			return nil, err
+		}
+		f.Params, err = r.readInt()
+		if err != nil {
+			return nil, err
+		}
+		f.RetCount, err = r.readInt()
+		if err != nil {
+			return nil, err
+		}
+		localCountU32, err := r.readU32()
+		if err != nil {
+			return nil, err
+		}
+		localCount := int(localCountU32)
+		locals := make([]IRLocal, 0, localCount)
+		for j := 0; j < localCount; j++ {
+			var l IRLocal
+			l.Name, err = r.readString()
+			if err != nil {
+				return nil, err
+			}
+			typeIdx, err := r.readInt()
+			if err != nil {
+				return nil, err
+			}
+			if typeIdx >= 0 && typeIdx < len(types) {
+				l.Type = types[typeIdx]
+			}
+			l.Index, err = r.readInt()
+			if err != nil {
+				return nil, err
+			}
+			l.Is64, err = r.readBool()
+			if err != nil {
+				return nil, err
+			}
+			l.Width, err = r.readInt()
+			if err != nil {
+				return nil, err
+			}
+			locals = append(locals, l)
+		}
+		f.Locals = locals
+		instCountU32, err := r.readU32()
+		if err != nil {
+			return nil, err
+		}
+		instCount := int(instCountU32)
+		code := make([]Inst, 0, instCount)
+		for j := 0; j < instCount; j++ {
+			var in Inst
+			op, err := r.readInt()
+			if err != nil {
+				return nil, err
+			}
+			in.Op = Opcode(op)
+			in.Arg, err = r.readInt()
+			if err != nil {
+				return nil, err
+			}
+			in.Width, err = r.readInt()
+			if err != nil {
+				return nil, err
+			}
+			in.Val, err = r.readI64()
+			if err != nil {
+				return nil, err
+			}
+			in.Name, err = r.readString()
+			if err != nil {
+				return nil, err
+			}
+			code = append(code, in)
+		}
+		f.Code = code
+		funcs = append(funcs, f)
+	}
+	return funcs, nil
+}
+
+func readStringIntMap(r *irBinReader) (map[string]int, error) {
+	countU32, err := r.readU32()
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[string]int)
+	for i := 0; i < int(countU32); i++ {
+		k, err := r.readString()
+		if err != nil {
+			return nil, err
+		}
+		v, err := r.readInt()
+		if err != nil {
+			return nil, err
+		}
+		m[k] = v
+	}
+	return m, nil
+}
+
+func readStringStringMap(r *irBinReader) (map[string]string, error) {
+	countU32, err := r.readU32()
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[string]string)
+	for i := 0; i < int(countU32); i++ {
+		k, err := r.readString()
+		if err != nil {
+			return nil, err
+		}
+		v, err := r.readString()
+		if err != nil {
+			return nil, err
+		}
+		m[k] = v
+	}
+	return m, nil
+}
+
+func readIfaceMethodsMap(r *irBinReader) (map[string][]string, error) {
+	countU32, err := r.readU32()
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[string][]string)
+	for i := 0; i < int(countU32); i++ {
+		k, err := r.readString()
+		if err != nil {
+			return nil, err
+		}
+		nU32, err := r.readU32()
+		if err != nil {
+			return nil, err
+		}
+		ms := make([]string, int(nU32))
+		for j := 0; j < int(nU32); j++ {
+			ms[j], err = r.readString()
+			if err != nil {
+				return nil, err
+			}
+		}
+		m[k] = ms
+	}
+	return m, nil
+}
+
+func readIRBinary(path string) (*IRModule, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read file: %w", err)
+	}
+	r := &irBinReader{data: data}
+	if err := readIRMagic(r); err != nil {
+		return nil, fmt.Errorf("read magic at %d: %w", r.off, err)
+	}
+	types, err := readIRTypes(r)
+	if err != nil {
+		return nil, fmt.Errorf("read types at %d: %w", r.off, err)
+	}
+	rootTypes, err := readIRRootTypes(r, types)
+	if err != nil {
+		return nil, fmt.Errorf("read root types at %d: %w", r.off, err)
+	}
+	globals, err := readIRGlobals(r, types)
+	if err != nil {
+		return nil, fmt.Errorf("read globals at %d: %w", r.off, err)
+	}
+	funcs, err := readIRFuncs(r, types)
+	if err != nil {
+		return nil, fmt.Errorf("read funcs at %d: %w", r.off, err)
+	}
+	typeIDs, err := readStringIntMap(r)
+	if err != nil {
+		return nil, fmt.Errorf("read typeIDs at %d: %w", r.off, err)
+	}
+	methodTable, err := readStringStringMap(r)
+	if err != nil {
+		return nil, fmt.Errorf("read method table at %d: %w", r.off, err)
+	}
+	ifaceMethods, err := readIfaceMethodsMap(r)
+	if err != nil {
+		return nil, fmt.Errorf("read iface methods at %d: %w", r.off, err)
+	}
+	ifaceMethodRets, err := readStringIntMap(r)
+	if err != nil {
+		return nil, fmt.Errorf("read iface method returns at %d: %w", r.off, err)
+	}
+	return &IRModule{
+		Funcs:           funcs,
+		Globals:         globals,
+		Types:           rootTypes,
+		TypeIDs:         typeIDs,
+		MethodTable:     methodTable,
+		IfaceMethods:    ifaceMethods,
+		IfaceMethodRets: ifaceMethodRets,
+	}, nil
+}

--- a/std/compiler/ir_binary_codec_stub.go
+++ b/std/compiler/ir_binary_codec_stub.go
@@ -1,0 +1,13 @@
+//go:build !exp_ir_binary
+
+package main
+
+import "fmt"
+
+func writeIRBinary(irmod *IRModule, path string) error {
+	return fmt.Errorf("IR binary I/O is experimental; rebuild with -tags exp_ir_binary")
+}
+
+func readIRBinary(path string) (*IRModule, error) {
+	return nil, fmt.Errorf("IR binary I/O is experimental; rebuild with -tags exp_ir_binary")
+}

--- a/std/compiler/ir_binary_feature_disabled.go
+++ b/std/compiler/ir_binary_feature_disabled.go
@@ -1,0 +1,5 @@
+//go:build !exp_ir_binary
+
+package main
+
+const irBinaryEnabled = false

--- a/std/compiler/ir_binary_feature_enabled.go
+++ b/std/compiler/ir_binary_feature_enabled.go
@@ -1,0 +1,5 @@
+//go:build exp_ir_binary
+
+package main
+
+const irBinaryEnabled = true

--- a/std/compiler/main.go
+++ b/std/compiler/main.go
@@ -1,3 +1,5 @@
+//go:build !no_frontend
+
 package main
 
 import (
@@ -94,6 +96,8 @@ func main() {
 	var extraTags string
 	var parseOnly bool
 	var buildTagsPath string
+	var emitIRBinaryPath string
+	var fromIRBinaryPath string
 	var runMode bool
 	var stdinInput bool
 	var programArgs []string
@@ -189,6 +193,18 @@ func main() {
 		} else if os.Args[i] == "-parse-only" {
 			parseOnly = true
 			i = i + 1
+		} else if (os.Args[i] == "-emit-ir-binary" || os.Args[i] == "-from-ir-binary") && i+1 < len(os.Args) {
+			if !irBinaryEnabled {
+				fmt.Fprintf(os.Stderr, "IR binary I/O is experimental; rebuild with -tags exp_ir_binary\n")
+				runCleanup()
+				os.Exit(1)
+			}
+			if os.Args[i] == "-emit-ir-binary" {
+				emitIRBinaryPath = os.Args[i+1]
+			} else {
+				fromIRBinaryPath = os.Args[i+1]
+			}
+			i = i + 2
 		} else if os.Args[i] == "-list-build-tags" && i+1 < len(os.Args) {
 			buildTagsPath = os.Args[i+1]
 			i = i + 2
@@ -216,6 +232,11 @@ func main() {
 		}
 	}
 	if stdinInput {
+		if fromIRBinaryPath != "" {
+			fmt.Fprintf(os.Stderr, "cannot use - with -from-ir-binary\n")
+			runCleanup()
+			os.Exit(1)
+		}
 		err := readStdinSourceToTemp()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "rtg: failed to read stdin source: %v\n", err)
@@ -251,7 +272,12 @@ func main() {
 		outputPath = runTmpBin
 	}
 
-	if len(entryFiles) == 0 {
+	if fromIRBinaryPath != "" && len(entryFiles) > 0 {
+		fmt.Fprintf(os.Stderr, "cannot combine source files with -from-ir-binary\n")
+		runCleanup()
+		os.Exit(1)
+	}
+	if fromIRBinaryPath == "" && len(entryFiles) == 0 {
 		printHelp(os.Args[0], os.Stderr)
 		os.Exit(1)
 	}
@@ -283,95 +309,130 @@ func main() {
 	// Initialize embedded std if available
 	initEmbeddedStd()
 
-	// Determine base directory for the std library.
-	// When embedded std is available, skip the disk search entirely.
-	var baseDir string
-	if hasEmbeddedStd() {
-		baseDir = "."
+	var irmod *IRModule
+	if fromIRBinaryPath != "" {
+		if parseOnly {
+			fmt.Fprintf(os.Stderr, "-parse-only is not valid with -from-ir-binary\n")
+			runCleanup()
+			os.Exit(1)
+		}
+		if buildTagsPath != "" {
+			fmt.Fprintf(os.Stderr, "-list-build-tags is not valid with -from-ir-binary\n")
+			runCleanup()
+			os.Exit(1)
+		}
+		var err error
+		irmod, err = readIRBinary(fromIRBinaryPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error reading IR binary: %v\n", err)
+			runCleanup()
+			os.Exit(1)
+		}
+		if compilerDebug {
+			fmt.Fprintf(os.Stderr, "debug: loaded IR binary (%d funcs, %d globals)\n", len(irmod.Funcs), len(irmod.Globals))
+		}
 	} else {
-		cwd, err := os.Getwd()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error getting working directory: %v\n", err)
+		// Determine base directory for the std library.
+		// When embedded std is available, skip the disk search entirely.
+		var baseDir string
+		if hasEmbeddedStd() {
+			baseDir = "."
+		} else {
+			cwd, err := os.Getwd()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error getting working directory: %v\n", err)
+				runCleanup()
+				os.Exit(1)
+			}
+			// Walk up from cwd until we find a directory containing std/runtime/runtime.go
+			baseDir = cwd
+			search := cwd
+			for {
+				_, err := os.ReadFile(search + "/std/runtime/runtime.go")
+				if err == nil {
+					baseDir = search
+					break
+				}
+				parent := dirName(search)
+				if parent == search || parent == "" {
+					break
+				}
+				search = parent
+			}
+		}
+
+		if compilerDebug {
+			fmt.Fprintf(os.Stderr, "debug: resolving module (%d entry files)\n", len(entryFiles))
+		}
+		resetDiscoveredBuildTags()
+		mod := ResolveModule(baseDir, entryFiles)
+		if compilerDebug {
+			fmt.Fprintf(os.Stderr, "debug: resolved %d packages\n", len(mod.Packages))
+		}
+
+		if buildTagsPath != "" {
+			tags := getDiscoveredBuildTags()
+			var out string
+			for _, t := range tags {
+				out = out + t + "\n"
+			}
+			err := os.WriteFile(buildTagsPath, []byte(out), 0644)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error writing build tag list: %v\n", err)
+				runCleanup()
+				os.Exit(1)
+			}
+		}
+
+		if parseOnly {
+			runCleanup()
+			os.Exit(0)
+		}
+
+		// Validate cross-package references
+		valErrs := ValidateModule(mod)
+		if len(valErrs) > 0 {
+			fmt.Fprintf(os.Stderr, "\n%d validation errors:\n", len(valErrs))
+			for _, e := range valErrs {
+				fmt.Fprintf(os.Stderr, "  %s\n", e)
+			}
 			runCleanup()
 			os.Exit(1)
 		}
-		// Walk up from cwd until we find a directory containing std/runtime/runtime.go
-		baseDir = cwd
-		search := cwd
-		for {
-			_, err := os.ReadFile(search + "/std/runtime/runtime.go")
-			if err == nil {
-				baseDir = search
-				break
-			}
-			parent := dirName(search)
-			if parent == search || parent == "" {
-				break
-			}
-			search = parent
-		}
-	}
 
-	if compilerDebug {
-		fmt.Fprintf(os.Stderr, "debug: resolving module (%d entry files)\n", len(entryFiles))
-	}
-	resetDiscoveredBuildTags()
-	mod := ResolveModule(baseDir, entryFiles)
-	if compilerDebug {
-		fmt.Fprintf(os.Stderr, "debug: resolved %d packages\n", len(mod.Packages))
-	}
-
-	if buildTagsPath != "" {
-		tags := getDiscoveredBuildTags()
-		var out string
-		for _, t := range tags {
-			out = out + t + "\n"
+		// Compile to IR
+		if compilerDebug {
+			fmt.Fprintf(os.Stderr, "debug: compiling to IR\n")
 		}
-		err := os.WriteFile(buildTagsPath, []byte(out), 0644)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error writing build tag list: %v\n", err)
+		var errs []string
+		irmod, errs = CompileModule(mod)
+
+		if len(errs) > 0 {
+			fmt.Fprintf(os.Stderr, "\n%d compile errors:\n", len(errs))
+			for _, e := range errs {
+				fmt.Fprintf(os.Stderr, "  %s\n", e)
+			}
 			runCleanup()
 			os.Exit(1)
 		}
-	}
 
-	if parseOnly {
-		runCleanup()
-		os.Exit(0)
-	}
-
-	// Validate cross-package references
-	valErrs := ValidateModule(mod)
-	if len(valErrs) > 0 {
-		fmt.Fprintf(os.Stderr, "\n%d validation errors:\n", len(valErrs))
-		for _, e := range valErrs {
-			fmt.Fprintf(os.Stderr, "  %s\n", e)
+		if compilerDebug {
+			fmt.Fprintf(os.Stderr, "debug: IR compiled (%d funcs, %d globals)\n", len(irmod.Funcs), len(irmod.Globals))
 		}
-		runCleanup()
-		os.Exit(1)
-	}
-
-	// Compile to IR
-	if compilerDebug {
-		fmt.Fprintf(os.Stderr, "debug: compiling to IR\n")
-	}
-	irmod, errs := CompileModule(mod)
-
-	if len(errs) > 0 {
-		fmt.Fprintf(os.Stderr, "\n%d compile errors:\n", len(errs))
-		for _, e := range errs {
-			fmt.Fprintf(os.Stderr, "  %s\n", e)
+		eliminateDeadFunctions(irmod)
+		if compilerDebug {
+			fmt.Fprintf(os.Stderr, "debug: DCE done (%d funcs remaining)\n", len(irmod.Funcs))
 		}
-		runCleanup()
-		os.Exit(1)
-	}
-
-	if compilerDebug {
-		fmt.Fprintf(os.Stderr, "debug: IR compiled (%d funcs, %d globals)\n", len(irmod.Funcs), len(irmod.Globals))
-	}
-	eliminateDeadFunctions(irmod)
-	if compilerDebug {
-		fmt.Fprintf(os.Stderr, "debug: DCE done (%d funcs remaining)\n", len(irmod.Funcs))
+		if emitIRBinaryPath != "" {
+			err := writeIRBinary(irmod, emitIRBinaryPath)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error writing IR binary: %v\n", err)
+				runCleanup()
+				os.Exit(1)
+			}
+			runCleanup()
+			os.Exit(0)
+		}
 	}
 
 	// Set VM program arguments if using VM backend
@@ -450,6 +511,10 @@ func printHelp(program string, out *os.File) {
 	fmt.Fprintf(out, "  -T <target>            Target triple or backend mode\n")
 	fmt.Fprintf(out, "  -tags <a,b,c>          Extra build tags\n")
 	fmt.Fprintf(out, "  -parse-only            Parse and resolve imports only (no codegen)\n")
+	if irBinaryEnabled {
+		fmt.Fprintf(out, "  -emit-ir-binary <p>    Compile source and write binary IR module to path\n")
+		fmt.Fprintf(out, "  -from-ir-binary <p>    Load binary IR module from path and run codegen\n")
+	}
 	fmt.Fprintf(out, "  -list-build-tags <p>   Write discovered build tags (one per line)\n")
 	fmt.Fprintf(out, "  -run                   Compile and run the output binary\n")
 	fmt.Fprintf(out, "  -size-analysis <path>  Write per-function size analysis JSON\n")

--- a/std/compiler/main_no_frontend.go
+++ b/std/compiler/main_no_frontend.go
@@ -1,0 +1,206 @@
+//go:build no_frontend && exp_ir_binary
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+)
+
+// Target and build tag globals — defaults to host platform
+var targetGOOS string = runtime.GOOS
+var targetGOARCH string = runtime.GOARCH
+var targetPtrSize int = defaultPtrSize()
+
+func defaultPtrSize() int {
+	if runtime.GOARCH == "386" || runtime.GOARCH == "wasm32" {
+		return 4
+	}
+	return 8
+}
+
+var targetBackend string = "native"       // native, c, ir, or vm
+var targetCModel int = 0                  // 16/32/64 when targetBackend==c
+var targetWordSize int = defaultPtrSize() // word size in bytes
+var buildTags []string
+var compilerDebug bool
+var stripBinary bool
+
+func main() {
+	if len(os.Args) < 2 {
+		printHelp(os.Args[0], os.Stderr)
+		os.Exit(1)
+	}
+
+	outputPath := "output"
+	var fromIRBinaryPath string
+	var extraTags string
+	i := 1
+	for i < len(os.Args) {
+		if os.Args[i] == "-h" || os.Args[i] == "--help" {
+			printHelp(os.Args[0], os.Stdout)
+			os.Exit(0)
+		} else if os.Args[i] == "-o" && i+1 < len(os.Args) {
+			outputPath = os.Args[i+1]
+			i = i + 2
+		} else if os.Args[i] == "-T" && i+1 < len(os.Args) {
+			target := os.Args[i+1]
+			if target == "c" || strings.HasPrefix(target, "c/") {
+				targetBackend = "c"
+				targetCModel = 64
+				if strings.HasPrefix(target, "c/") {
+					model := target[2:]
+					if model == "16" {
+						targetCModel = 16
+					} else if model == "32" {
+						targetCModel = 32
+					} else if model == "64" {
+						targetCModel = 64
+					} else {
+						fmt.Fprintf(os.Stderr, "invalid target %q: expected c, c/16, c/32, or c/64\n", target)
+						os.Exit(1)
+					}
+				}
+				if targetCModel == 16 {
+					targetPtrSize = 2
+				} else if targetCModel == 32 {
+					targetPtrSize = 4
+				} else {
+					targetPtrSize = 8
+				}
+				targetGOOS = "c"
+				targetGOARCH = fmt.Sprintf("c%d", targetCModel)
+			} else if target == "ir" {
+				targetBackend = "ir"
+			} else if strings.HasPrefix(target, "vm/") {
+				targetBackend = "vm"
+				model := target[3:]
+				if model == "8" {
+					targetWordSize = 1
+					targetPtrSize = 2
+				} else if model == "16" {
+					targetWordSize = 2
+					targetPtrSize = 2
+				} else if model == "32" {
+					targetWordSize = 4
+					targetPtrSize = 4
+				} else if model == "64" {
+					targetWordSize = 8
+					targetPtrSize = 8
+				} else {
+					fmt.Fprintf(os.Stderr, "invalid target %q: expected vm/8, vm/16, vm/32, or vm/64\n", target)
+					os.Exit(1)
+				}
+				targetGOOS = "c"
+				bits := targetWordSize * 8
+				targetGOARCH = fmt.Sprintf("c%d", bits)
+			} else {
+				if target == "dos/8086" {
+					targetGOOS = "dos"
+					targetGOARCH = "dos16"
+					targetPtrSize = 2
+					i = i + 2
+					continue
+				}
+				slashIdx := strings.Index(target, "/")
+				if slashIdx < 0 {
+					fmt.Fprintf(os.Stderr, "invalid target %q: expected os/arch, dos/8086, c[/16|32|64], ir, or vm/<8|16|32|64>\n", target)
+					os.Exit(1)
+				}
+				targetGOOS = target[0:slashIdx]
+				targetGOARCH = target[slashIdx+1:]
+				if targetGOARCH == "386" || targetGOARCH == "wasm32" {
+					targetPtrSize = 4
+				} else {
+					targetPtrSize = 8
+				}
+			}
+			i = i + 2
+		} else if os.Args[i] == "-from-ir-binary" && i+1 < len(os.Args) {
+			fromIRBinaryPath = os.Args[i+1]
+			i = i + 2
+		} else if os.Args[i] == "-size-analysis" && i+1 < len(os.Args) {
+			sizeAnalysisPath = os.Args[i+1]
+			i = i + 2
+		} else if os.Args[i] == "-tags" && i+1 < len(os.Args) {
+			extraTags = os.Args[i+1]
+			i = i + 2
+		} else if os.Args[i] == "-debug" {
+			compilerDebug = true
+			i = i + 1
+		} else if os.Args[i] == "-strip" || os.Args[i] == "-s" {
+			stripBinary = true
+			i = i + 1
+		} else {
+			fmt.Fprintf(os.Stderr, "no_frontend build only supports -from-ir-binary input\n")
+			os.Exit(1)
+		}
+	}
+
+	if fromIRBinaryPath == "" {
+		fmt.Fprintf(os.Stderr, "no_frontend build requires -from-ir-binary <path>\n")
+		os.Exit(1)
+	}
+
+	// Build active tag set from target + explicit tags.
+	if targetBackend == "c" {
+		buildTags = append(buildTags, "c")
+		buildTags = append(buildTags, fmt.Sprintf("c%d", targetCModel))
+	} else if targetGOOS == "wasi" && targetGOARCH == "wasm32" {
+		buildTags = append(buildTags, "wasi")
+		buildTags = append(buildTags, "wasm32")
+	} else {
+		buildTags = append(buildTags, targetGOOS)
+		buildTags = append(buildTags, targetGOARCH)
+	}
+	if extraTags != "" {
+		parts := strings.Split(extraTags, ",")
+		for _, t := range parts {
+			if t != "" {
+				buildTags = append(buildTags, t)
+			}
+		}
+	}
+	buildTags = append(buildTags, "rtg")
+	if sizeAnalysisPath != "" {
+		stripBinary = true
+	}
+
+	initEmbeddedStd()
+
+	irmod, err := readIRBinary(fromIRBinaryPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error reading IR binary: %v\n", err)
+		os.Exit(1)
+	}
+	if compilerDebug {
+		fmt.Fprintf(os.Stderr, "debug: loaded IR binary (%d funcs, %d globals)\n", len(irmod.Funcs), len(irmod.Globals))
+		fmt.Fprintf(os.Stderr, "debug: generating output (backend=%s, target=%s/%s)\n", targetBackend, targetGOOS, targetGOARCH)
+	}
+	err = GenerateELF(irmod, outputPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "codegen error: %v\n", err)
+		os.Exit(1)
+	}
+	writeSizeAnalysis()
+	if targetBackend == "vm" {
+		os.Exit(vmExitCode)
+	}
+}
+
+func printHelp(program string, out *os.File) {
+	fmt.Fprintf(out, "Usage: %s [options] -from-ir-binary <module.irb>\n", program)
+	fmt.Fprintf(out, "\nThis build is backend-only (built with no_frontend,exp_ir_binary).\n")
+	fmt.Fprintf(out, "\nOptions:\n")
+	fmt.Fprintf(out, "  -o <path>              Output path (default: output)\n")
+	fmt.Fprintf(out, "  -T <target>            Target triple or backend mode\n")
+	fmt.Fprintf(out, "  -from-ir-binary <p>    Load binary IR module from path and run codegen\n")
+	fmt.Fprintf(out, "  -tags <a,b,c>          Extra build tags\n")
+	fmt.Fprintf(out, "  -size-analysis <path>  Write per-function size analysis JSON\n")
+	fmt.Fprintf(out, "  -debug                 Enable compiler debug logging\n")
+	fmt.Fprintf(out, "  -strip, -s             Strip symbol/debug metadata from native binaries\n")
+	fmt.Fprintf(out, "  -h, --help             Show this help\n")
+	fmt.Fprintf(out, "\nDefault target: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+}

--- a/std/compiler/main_no_frontend_no_irbin.go
+++ b/std/compiler/main_no_frontend_no_irbin.go
@@ -1,0 +1,13 @@
+//go:build no_frontend && !exp_ir_binary
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Fprintf(os.Stderr, "no_frontend build requires experimental IR binary mode; rebuild with -tags exp_ir_binary\n")
+	os.Exit(1)
+}

--- a/tools/Buildfile
+++ b/tools/Buildfile
@@ -20,8 +20,8 @@ selfhost-size-native-tags: build
   sh ./build/stage1 -o build/stage2 compiler
   sh ./build/stage2 -size-analysis build/stage2.size.default.json -o build/rtg.stage2.default compiler
   sh ./build/stage2 -s -size-analysis build/stage2.size.default.strip.json -o build/rtg.stage2.default.strip compiler
-  sh ./build/stage2 -tags no_backend_arm64,no_backend_linux_i386,no_backend_windows_amd64,no_backend_windows_i386,no_backend_wasi_wasm32,no_backend_c,no_backend_dos_i386 -size-analysis build/stage2.size.native_only.json -o build/rtg.stage2.native_only compiler
-  sh ./build/stage2 -tags no_backend_arm64,no_backend_linux_i386,no_backend_windows_amd64,no_backend_windows_i386,no_backend_wasi_wasm32,no_backend_c,no_backend_dos_i386,no_backend_ir -size-analysis build/stage2.size.native_strict.json -o build/rtg.stage2.native_strict compiler
+  sh ./build/stage2 -tags no_backend_arm64,no_backend_linux_i386,no_backend_windows_amd64,no_backend_windows_i386,no_backend_wasi_wasm32,no_backend_c,no_backend_dos_i386,no_backend_vm -size-analysis build/stage2.size.native_only.json -o build/rtg.stage2.native_only compiler
+  sh ./build/stage2 -tags no_backend_arm64,no_backend_linux_i386,no_backend_windows_amd64,no_backend_windows_i386,no_backend_wasi_wasm32,no_backend_c,no_backend_dos_i386,no_backend_ir,no_backend_vm -size-analysis build/stage2.size.native_strict.json -o build/rtg.stage2.native_strict compiler
   sh ./build/rtg.stage2.default -h >/dev/null
   sh ./build/rtg.stage2.default.strip -h >/dev/null
   sh ./build/rtg.stage2.native_only -h >/dev/null
@@ -33,7 +33,7 @@ selfhost-size-native-tags: build
 test-tagset-windows386-only: build
   sh ./build/rtg -o build/stage1 ./std/compiler/
   sh ./build/stage1 -o build/stage2 compiler
-  sh for t in windows/386 windows/amd64 windows/arm64 linux/amd64 linux/arm64 darwin/arm64; do out=build/tagcheck_$(echo "$t" | tr / _)_windows_i386_only; ./build/stage2 -T "$t" -tags no_backend_linux_amd64,no_backend_windows_amd64,no_backend_arm64,no_backend_wasi_wasm32,no_backend_c,no_backend_dos_i386,no_backend_linux_i386 -o "$out" ./std/compiler/; done
+  sh for t in windows/386 windows/amd64 windows/arm64 linux/amd64 linux/arm64 darwin/arm64; do out=build/tagcheck_$(echo "$t" | tr / _)_windows_i386_only; ./build/stage2 -T "$t" -tags no_backend_linux_amd64,no_backend_windows_amd64,no_backend_arm64,no_backend_wasi_wasm32,no_backend_c,no_backend_dos_i386,no_backend_linux_i386,no_backend_vm -o "$out" ./std/compiler/; done
   sh echo "PASS: windows/386-only tag set builds for native targets"
 
 test-size-analysis-tagsets: build
@@ -41,7 +41,7 @@ test-size-analysis-tagsets: build
   sh ./build/stage1 -o build/stage2 compiler
   sh rm -f build/*.go
   sh echo package build > build/_rtg_buildpkg.go
-  sh set -eu; for t in windows/386 windows/amd64 windows/arm64 linux/amd64 linux/arm64 darwin/arm64 wasi/wasm32; do tid=$(echo "$t" | tr / _); case "$t" in windows/*) ext=.exe ;; wasi/wasm32) ext=.wasm ;; *) ext= ;; esac; for cfg in full no_embed_std backend_linux_amd64_only backend_windows_i386_only backend_windows_amd64_only backend_arm64_only backend_wasi_wasm32_only; do echo "matrix: $t / $cfg"; tags=; case "$cfg" in full) tags= ;; no_embed_std) tags=no_embed_std ;; backend_linux_amd64_only) tags=no_backend_windows_i386,no_backend_windows_amd64,no_backend_arm64,no_backend_wasi_wasm32,no_backend_c,no_backend_dos_i386,no_backend_linux_i386 ;; backend_windows_i386_only) tags=no_backend_linux_amd64,no_backend_windows_amd64,no_backend_arm64,no_backend_wasi_wasm32,no_backend_c,no_backend_dos_i386,no_backend_linux_i386 ;; backend_windows_amd64_only) tags=no_backend_linux_amd64,no_backend_windows_i386,no_backend_arm64,no_backend_wasi_wasm32,no_backend_c,no_backend_dos_i386,no_backend_linux_i386 ;; backend_arm64_only) tags=no_backend_linux_amd64,no_backend_windows_i386,no_backend_windows_amd64,no_backend_wasi_wasm32,no_backend_c,no_backend_dos_i386,no_backend_linux_i386 ;; backend_wasi_wasm32_only) tags=no_backend_linux_amd64,no_backend_windows_i386,no_backend_windows_amd64,no_backend_arm64,no_backend_c,no_backend_dos_i386,no_backend_linux_i386 ;; *) echo "unknown cfg $cfg" >&2; exit 1 ;; esac; out=build/sizecheck_${tid}_${cfg}${ext}; json=build/sizecheck_${tid}_${cfg}.json; if [ "$cfg" = full ]; then ./build/stage2 -T "$t" -size-analysis "$json" -o "$out" ./std/compiler/; else ./build/stage2 -T "$t" -tags "$tags" -size-analysis "$json" -o "$out" ./std/compiler/; fi; done; done
+  sh set -eu; for t in windows/386 windows/amd64 windows/arm64 linux/amd64 linux/arm64 darwin/arm64 wasi/wasm32; do tid=$(echo "$t" | tr / _); case "$t" in windows/*) ext=.exe ;; wasi/wasm32) ext=.wasm ;; *) ext= ;; esac; for cfg in full no_embed_std backend_linux_amd64_only backend_windows_i386_only backend_windows_amd64_only backend_arm64_only backend_wasi_wasm32_only; do echo "matrix: $t / $cfg"; tags=; case "$cfg" in full) tags= ;; no_embed_std) tags=no_embed_std,no_backend_vm ;; backend_linux_amd64_only) tags=no_backend_windows_i386,no_backend_windows_amd64,no_backend_arm64,no_backend_wasi_wasm32,no_backend_c,no_backend_dos_i386,no_backend_linux_i386,no_backend_vm ;; backend_windows_i386_only) tags=no_backend_linux_amd64,no_backend_windows_amd64,no_backend_arm64,no_backend_wasi_wasm32,no_backend_c,no_backend_dos_i386,no_backend_linux_i386,no_backend_vm ;; backend_windows_amd64_only) tags=no_backend_linux_amd64,no_backend_windows_i386,no_backend_arm64,no_backend_wasi_wasm32,no_backend_c,no_backend_dos_i386,no_backend_linux_i386,no_backend_vm ;; backend_arm64_only) tags=no_backend_linux_amd64,no_backend_windows_i386,no_backend_windows_amd64,no_backend_wasi_wasm32,no_backend_c,no_backend_dos_i386,no_backend_linux_i386,no_backend_vm ;; backend_wasi_wasm32_only) tags=no_backend_linux_amd64,no_backend_windows_i386,no_backend_windows_amd64,no_backend_arm64,no_backend_c,no_backend_dos_i386,no_backend_linux_i386,no_backend_vm ;; *) echo "unknown cfg $cfg" >&2; exit 1 ;; esac; out=build/sizecheck_${tid}_${cfg}${ext}; json=build/sizecheck_${tid}_${cfg}.json; if [ "$cfg" = full ]; then ./build/stage2 -T "$t" -size-analysis "$json" -o "$out" ./std/compiler/; else ./build/stage2 -T "$t" -tags "$tags" -size-analysis "$json" -o "$out" ./std/compiler/; fi; done; done
   sh rm -f build/_rtg_buildpkg.go
   sh echo "PASS: size-analysis tagset matrix OK"
 
@@ -90,6 +90,67 @@ selfhost-win386: build
   sh wine build/stage1.exe -T windows/386 -o build/stage2.exe compiler
   sh wine build/stage2.exe -T windows/386 -o build/stage3.exe compiler
   sh cmp build/stage2.exe build/stage3.exe && echo "PASS: windows/386 self-hosting OK"
+
+selfhost-exp: selfhost
+  sh ./build/stage2 -tags exp_ir_binary,no_backend_vm -o build/stage2_exp compiler
+  sh ./build/stage2_exp -tags no_frontend,exp_ir_binary,no_backend_vm -o build/stage2_exp_backend compiler
+  sh ./build/stage2_exp -emit-ir-binary build/selfhost_exp_native.irb tests/types_int.go
+  sh ./build/stage2_exp_backend -from-ir-binary build/selfhost_exp_native.irb -o build/selfhost_exp_native
+  sh ./build/selfhost_exp_native >/dev/null
+  sh echo "PASS: self-hosting experimental IR binary roundtrip OK"
+
+selfhost-exp-i386: selfhost-i386
+  sh ./build/stage2_i386 -T linux/386 -tags exp_ir_binary,no_backend_vm -o build/stage2_i386_exp compiler
+  sh ./build/stage2_i386_exp -T linux/386 -tags no_frontend,exp_ir_binary,no_backend_vm -o build/stage2_i386_exp_backend compiler
+  sh ./build/stage2_i386_exp -T linux/386 -emit-ir-binary build/selfhost_exp_i386.irb tests/types_int.go
+  sh ./build/stage2_i386_exp_backend -T linux/386 -from-ir-binary build/selfhost_exp_i386.irb -o build/selfhost_exp_i386
+  sh ./build/selfhost_exp_i386 >/dev/null
+  sh echo "PASS: i386 experimental IR binary roundtrip OK"
+
+selfhost-exp-c: selfhost-c
+  sh ./build/stage2_c -T c/64 -tags exp_ir_binary,no_backend_vm -o build/stage2_c_exp.c compiler
+  sh ${CC:-cc} build/stage2_c_exp.c -o build/stage2_c_exp
+  sh ./build/stage2_c_exp -T c/64 -tags no_frontend,exp_ir_binary,no_backend_vm -o build/stage2_c_exp_backend.c compiler
+  sh ${CC:-cc} build/stage2_c_exp_backend.c -o build/stage2_c_exp_backend
+  sh ./build/stage2_c_exp -T c/64 -emit-ir-binary build/selfhost_exp_c.irb tests/types_int.go
+  sh ./build/stage2_c_exp_backend -T c/64 -from-ir-binary build/selfhost_exp_c.irb -o build/selfhost_exp_c_out.c
+  sh ${CC:-cc} build/selfhost_exp_c_out.c -o build/selfhost_exp_c_out
+  sh ./build/selfhost_exp_c_out >/dev/null
+  sh echo "PASS: C experimental IR binary roundtrip OK"
+
+selfhost-exp-wasm: selfhost-wasm
+  sh wasmtime --dir=. build/stage2.wasm -T wasi/wasm32 -tags exp_ir_binary,no_backend_vm -o build/stage2_exp.wasm compiler
+  sh wasmtime --dir=. build/stage2_exp.wasm -T wasi/wasm32 -tags no_frontend,exp_ir_binary,no_backend_vm -o build/stage2_exp_backend.wasm compiler
+  sh wasmtime --dir=. build/stage2_exp.wasm -T wasi/wasm32 -emit-ir-binary build/selfhost_exp_wasm.irb tests/types_int.go
+  sh wasmtime --dir=. build/stage2_exp_backend.wasm -T wasi/wasm32 -from-ir-binary build/selfhost_exp_wasm.irb -o build/selfhost_exp_wasm_out.wasm
+  sh wasmtime --dir=. build/selfhost_exp_wasm_out.wasm >/dev/null
+  sh echo "PASS: wasm experimental IR binary roundtrip OK"
+
+selfhost-exp-winarm64: selfhost-winarm64
+  sh ./build/stage2_winarm64.exe -T windows/arm64 -tags exp_ir_binary,no_backend_vm -o build/stage2_winarm64_exp.exe compiler
+  sh ./build/stage2_winarm64_exp.exe -T windows/arm64 -tags no_frontend,exp_ir_binary,no_backend_vm -o build/stage2_winarm64_exp_backend.exe compiler
+  sh ./build/stage2_winarm64_exp.exe -T windows/arm64 -emit-ir-binary build/selfhost_exp_winarm64.irb tests/types_int.go
+  sh ./build/stage2_winarm64_exp_backend.exe -T windows/arm64 -from-ir-binary build/selfhost_exp_winarm64.irb -o build/selfhost_exp_winarm64.exe
+  sh chmod +x build/selfhost_exp_winarm64.exe
+  sh ./build/selfhost_exp_winarm64.exe >/dev/null
+  sh echo "PASS: windows/arm64 experimental IR binary roundtrip OK"
+
+selfhost-exp-winamd64: selfhost-winamd64
+  sh ./build/stage2_winamd64.exe -T windows/amd64 -tags exp_ir_binary,no_backend_vm -o build/stage2_winamd64_exp.exe compiler
+  sh ./build/stage2_winamd64_exp.exe -T windows/amd64 -tags no_frontend,exp_ir_binary,no_backend_vm -o build/stage2_winamd64_exp_backend.exe compiler
+  sh ./build/stage2_winamd64_exp.exe -T windows/amd64 -emit-ir-binary build/selfhost_exp_winamd64.irb tests/types_int.go
+  sh ./build/stage2_winamd64_exp_backend.exe -T windows/amd64 -from-ir-binary build/selfhost_exp_winamd64.irb -o build/selfhost_exp_winamd64.exe
+  sh chmod +x build/selfhost_exp_winamd64.exe
+  sh ./build/selfhost_exp_winamd64.exe >/dev/null
+  sh echo "PASS: windows/amd64 experimental IR binary roundtrip OK"
+
+selfhost-exp-win386: selfhost-win386
+  sh wine build/stage2.exe -T windows/386 -tags exp_ir_binary,no_backend_vm -o build/stage2_exp.exe compiler
+  sh wine build/stage2_exp.exe -T windows/386 -tags no_frontend,exp_ir_binary,no_backend_vm -o build/stage2_exp_backend.exe compiler
+  sh wine build/stage2_exp.exe -T windows/386 -emit-ir-binary build/selfhost_exp_win386.irb tests/types_int.go
+  sh wine build/stage2_exp_backend.exe -T windows/386 -from-ir-binary build/selfhost_exp_win386.irb -o build/selfhost_exp_win386.exe
+  sh wine build/selfhost_exp_win386.exe >/dev/null
+  sh echo "PASS: windows/386 experimental IR binary roundtrip OK"
 
 crosscompile-wasm-native: build
   sh ./build/rtg -T wasi/wasm32 -o build/cross_stage1.wasm ./std/compiler/


### PR DESCRIPTION
## Summary
- rename no_frontmid split mode to no_frontend
- add alternate backend-only main for no_frontend
- gate IR binary read/write behind exp_ir_binary (disabled by default)
- gate VM backend behind no_backend_vm and add stubs
- update Buildfile with separate selfhost-exp-* targets so normal selfhost remains non-blocking
- keep minimal size-analysis tagsets excluding VM for backend-focused size checks

## Validation
- ./build/build selfhost
- ./build/build selfhost-exp
- ./build/build selfhost-exp-i386
- ./build/build selfhost-exp-wasm
- ./build/build selfhost-size-native-tags
- ./build/build test-size-analysis-tagsets