### PR TITLE
Add refined compiler-bug repro scaffolds, analysis, and compile matrix

### DIFF
--- a/tests/compiler_bugs_repros/01_backend_interface_helper_call.go
+++ b/tests/compiler_bugs_repros/01_backend_interface_helper_call.go
@@ -1,0 +1,24 @@
+package main
+
+type Backend interface {
+	Name() string
+}
+
+type nativeBackend struct{}
+
+func (b nativeBackend) Name() string { return "native" }
+
+func getRegisteredBackend(name string) (Backend, bool) {
+	if name == "native" {
+		return nativeBackend{}, true
+	}
+	return nil, false
+}
+
+func main() {
+	b, ok := getRegisteredBackend("native")
+	if !ok {
+		return
+	}
+	_ = b.Name() // C selfhost repro shape: interface value returned from helper, then method call.
+}

--- a/tests/compiler_bugs_repros/02_unnamed_receiver_rejected.go
+++ b/tests/compiler_bugs_repros/02_unnamed_receiver_rejected.go
@@ -1,0 +1,9 @@
+package main
+
+type T struct{}
+
+func (T) M() {}
+
+func main() {
+	T{}.M() // Parser currently rejects unnamed receiver identifiers in selfhost mode.
+}

--- a/tests/compiler_bugs_repros/03_error_method_on_helper_result.go
+++ b/tests/compiler_bugs_repros/03_error_method_on_helper_result.go
@@ -1,0 +1,16 @@
+package main
+
+type simpleErr struct{}
+
+func (e simpleErr) Error() string { return "boom" }
+
+func helper() error {
+	return simpleErr{}
+}
+
+func main() {
+	err := helper()
+	if err != nil {
+		_ = err.Error() // Selfhost unresolved call repro shape.
+	}
+}

--- a/tests/compiler_bugs_repros/04_driver_options_threading_instability.go
+++ b/tests/compiler_bugs_repros/04_driver_options_threading_instability.go
@@ -1,0 +1,21 @@
+package main
+
+type DriverOptions struct {
+	Verbose bool
+}
+
+func helperWithOptions(opts DriverOptions, in string) string {
+	if opts.Verbose {
+		return in + "!"
+	}
+	return in
+}
+
+func helperWithoutOptions(in string) string {
+	return in
+}
+
+func main() {
+	opts := DriverOptions{}
+	_, _ = helperWithOptions(opts, "x"), helperWithoutOptions("x") // Stage drift repro shape.
+}

--- a/tests/compiler_bugs_repros/05_function_typed_parameter_call.go
+++ b/tests/compiler_bugs_repros/05_function_typed_parameter_call.go
@@ -1,0 +1,9 @@
+package main
+
+func wrapper(fn func()) {
+	fn() // Selfhost unresolved call repro shape: unresolved calls: fn.
+}
+
+func main() {
+	wrapper(func() {})
+}

--- a/tests/compiler_bugs_repros/06_apply_restore_wrapper_drift.go
+++ b/tests/compiler_bugs_repros/06_apply_restore_wrapper_drift.go
@@ -1,0 +1,18 @@
+package main
+
+type FrontendOptions struct {
+	Strict bool
+}
+
+func withOptions(opts *FrontendOptions, strict bool, fn func()) {
+	prev := opts.Strict
+	opts.Strict = strict
+	fn()
+	opts.Strict = prev
+}
+
+func main() {
+	opts := &FrontendOptions{}
+	withOptions(opts, true, func() {})
+	withOptions(opts, false, func() {}) // Repeated apply/restore helper drift repro shape.
+}

--- a/tests/compiler_bugs_repros/07_frontend_options_conversion_helper.go
+++ b/tests/compiler_bugs_repros/07_frontend_options_conversion_helper.go
@@ -1,0 +1,13 @@
+package main
+
+type DriverOptions struct{ Strict bool }
+type FrontendOptions struct{ Strict bool }
+
+func frontendOptionsFromDriver(d DriverOptions) FrontendOptions {
+	return FrontendOptions{Strict: d.Strict}
+}
+
+func main() {
+	d := DriverOptions{Strict: true}
+	_ = frontendOptionsFromDriver(d) // Deterministic drift repro shape in main option-conversion path.
+}

--- a/tests/compiler_bugs_repros/08_backend_map_interface_registry.go
+++ b/tests/compiler_bugs_repros/08_backend_map_interface_registry.go
@@ -1,0 +1,16 @@
+package main
+
+type Backend interface {
+	Emit() string
+}
+
+type cBackend struct{}
+
+func (b cBackend) Emit() string { return "c" }
+
+func main() {
+	registry := map[string]Backend{
+		"c": cBackend{},
+	}
+	_ = registry["c"].Emit() // Interface-valued map lookup dispatch drift repro shape.
+}

--- a/tests/compiler_bugs_repros/09_wasm_cross_selfhost_global_init_drift.go
+++ b/tests/compiler_bugs_repros/09_wasm_cross_selfhost_global_init_drift.go
@@ -1,0 +1,10 @@
+package main
+
+var globals = []string{
+	"runtime/runtime_linux_amd64.go",
+	"runtime/runtime_wasi_wasm32.go",
+}
+
+func main() {
+	_ = globals // Repro scaffold for cross-stage global-init drift investigation.
+}

--- a/tests/compiler_bugs_repros/10_embed_name_data_mismatch.go
+++ b/tests/compiler_bugs_repros/10_embed_name_data_mismatch.go
@@ -1,0 +1,14 @@
+package main
+
+type embedEntry struct {
+	Name string
+	Data string
+}
+
+var embedded = []embedEntry{
+	{Name: "runtime/runtime_linux_amd64.go", Data: "// wasi runtime bytes ..."},
+}
+
+func main() {
+	_ = embedded // Repro scaffold for embed name/data association corruption.
+}

--- a/tests/compiler_bugs_repros/11_embed_walk_before_embedded_fs.go
+++ b/tests/compiler_bugs_repros/11_embed_walk_before_embedded_fs.go
@@ -1,0 +1,20 @@
+package main
+
+func walkEmbedDir() []string {
+	return []string{"std/runtime/runtime.go"}
+}
+
+func loadEmbeddedFS() []string {
+	return []string{"std/runtime/runtime.go"}
+}
+
+func loadSources() []string {
+	if files := walkEmbedDir(); len(files) > 0 {
+		return files
+	}
+	return loadEmbeddedFS()
+}
+
+func main() {
+	_ = loadSources() // Repro scaffold for embed-init path drift when preferring disk walk.
+}

--- a/tests/compiler_bugs_repros/12_native_backend_callback_helpers.go
+++ b/tests/compiler_bugs_repros/12_native_backend_callback_helpers.go
@@ -1,0 +1,19 @@
+package main
+
+func compileFunc(fn func()) {
+	fn() // Repro shape for unresolved calls through callback-style helpers.
+}
+
+func emitTostringHelper(fn func()) {
+	fn()
+}
+
+func patchAt(fn func()) {
+	fn()
+}
+
+func main() {
+	compileFunc(func() {})
+	emitTostringHelper(func() {})
+	patchAt(func() {})
+}

--- a/tests/compiler_bugs_repros/13_collapsed_native_generator_entrypoint.go
+++ b/tests/compiler_bugs_repros/13_collapsed_native_generator_entrypoint.go
@@ -1,0 +1,21 @@
+package main
+
+type profile int
+
+const (
+	profileDefault profile = iota
+	profileTiny
+)
+
+func generateWithProfile(p profile) int {
+	switch p {
+	case profileTiny:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func main() {
+	_, _ = generateWithProfile(profileDefault), generateWithProfile(profileTiny) // Helperized control-flow drift shape.
+}

--- a/tests/compiler_bugs_repros/14_frontend_interface_dispatch_crash.go
+++ b/tests/compiler_bugs_repros/14_frontend_interface_dispatch_crash.go
@@ -1,0 +1,14 @@
+package main
+
+type Frontend interface {
+	Compile() error
+}
+
+type defaultFrontend struct{}
+
+func (f defaultFrontend) Compile() error { return nil }
+
+func main() {
+	var f Frontend = defaultFrontend{}
+	_ = f.Compile() // Repro shape for interface-based frontend dispatch instability.
+}

--- a/tests/compiler_bugs_repros/15_function_value_dispatch_map.go
+++ b/tests/compiler_bugs_repros/15_function_value_dispatch_map.go
@@ -1,0 +1,11 @@
+package main
+
+func genA() {}
+
+func main() {
+	generators := map[string]func(){
+		"a": genA,
+	}
+	gen := generators["a"]
+	gen() // Selfhost unresolved call repro shape: unresolved calls: gen.
+}

--- a/tests/compiler_bugs_repros/16_backend_interface_registry_crash.go
+++ b/tests/compiler_bugs_repros/16_backend_interface_registry_crash.go
@@ -1,0 +1,14 @@
+package main
+
+type Backend interface {
+	Compile() error
+}
+
+type nativeBackend struct{}
+
+func (b nativeBackend) Compile() error { return nil }
+
+func main() {
+	registry := map[string]Backend{"native": nativeBackend{}}
+	_ = registry["native"].Compile() // Repro shape for backend interface dispatch instability.
+}

--- a/tests/compiler_bugs_repros/17_error_method_in_runmode_helper.go
+++ b/tests/compiler_bugs_repros/17_error_method_in_runmode_helper.go
@@ -1,0 +1,20 @@
+package main
+
+type runErr struct{}
+
+func (e runErr) Error() string { return "failed" }
+
+func runMode() error {
+	return runErr{}
+}
+
+func report(err error) string {
+	if err == nil {
+		return "ok"
+	}
+	return err.Error() // Repro shape for unresolved calls: err.Error.
+}
+
+func main() {
+	_ = report(runMode())
+}

--- a/tests/compiler_bugs_repros/18_exiterror_assertion_helper.go
+++ b/tests/compiler_bugs_repros/18_exiterror_assertion_helper.go
@@ -1,0 +1,27 @@
+package main
+
+type ExitError struct {
+	Code int
+}
+
+func (e *ExitError) Error() string { return "exit" }
+
+func maybeWrap(err error) error {
+	return err
+}
+
+func handleRunError(err error) int {
+	err = maybeWrap(err)
+	if ee, ok := err.(*ExitError); ok {
+		_ = ee
+		return 1
+	}
+	if err != nil {
+		return 2
+	}
+	return 0
+}
+
+func main() {
+	_ = handleRunError(&ExitError{Code: 1}) // Repro shape for helperized type assertion instability.
+}

--- a/tests/compiler_bugs_repros/19_possible_targets_relocation.go
+++ b/tests/compiler_bugs_repros/19_possible_targets_relocation.go
@@ -1,0 +1,21 @@
+package main
+
+func appendUnique(list []string, item string) []string {
+	for _, v := range list {
+		if v == item {
+			return list
+		}
+	}
+	return append(list, item)
+}
+
+func possibleTargets(base []string) []string {
+	out := base
+	out = appendUnique(out, "linux/amd64")
+	out = appendUnique(out, "wasi/wasm32")
+	return out
+}
+
+func main() {
+	_ = possibleTargets(nil) // Repro shape for main helper relocation drift.
+}

--- a/tests/compiler_bugs_repros/README.md
+++ b/tests/compiler_bugs_repros/README.md
@@ -1,0 +1,7 @@
+# Compiler bug reproduction scaffolds
+
+These files are intentionally placed under `tests/compiler_bugs_repros/` so existing top-level test runners that scan `tests/*.go` do not trigger them automatically.
+
+Each file corresponds to one item from `COMPILER_BUGS` and preserves the problematic code shape as a minimal scaffold for manual selfhost/cross-selfhost investigation.
+
+See also `ROOT_CAUSE_ANALYSIS.md` for compile-matrix results and likely root-cause groupings.

--- a/tests/compiler_bugs_repros/ROOT_CAUSE_ANALYSIS.md
+++ b/tests/compiler_bugs_repros/ROOT_CAUSE_ANALYSIS.md
@@ -1,0 +1,50 @@
+# Compiler bug root-cause notes (repro scaffold pass)
+
+Command used for the matrix:
+
+```bash
+for f in tests/compiler_bugs_repros/*.go; do
+  ./build/rtg -T <target> -o /tmp/bugrepro_out/<name> "$f"
+done
+```
+
+`01` was compiled with `-T c/64`, all others with `-T linux/amd64`.
+
+## Findings by bug family
+
+1. **Unnamed receiver parser failure (`02`)**
+   - **Reproduced**.
+   - Root cause: parser receiver grammar requires `(<ident> <type>)` and does not accept type-only receivers (`(T)`). `parseReceiver` immediately `expect(TOKEN_IDENT)` then parses type, which rejects valid unnamed Go receivers.
+
+2. **Function-typed local call unresolved (`05`, `06`, `12`, `15`)**
+   - **Reproduced** (`unresolved calls: fn/gen`).
+   - Root cause: `resolveCallName` returns local identifier names for callable locals/function values, but backend call fixups are symbol-based direct calls and do not lower indirect/function-value calls.
+
+3. **Interface dispatch through selector/map lookups (`08`, `16`)**
+   - **Reproduced** (`unresolved calls: unknown`).
+   - Root cause: unresolved selector call paths return sentinel call target `"unknown"` when concrete receiver/method cannot be statically resolved for direct-call lowering.
+
+4. **Deterministic drift / stage mismatch class (`04`, `07`, `09`, `10`, `11`, `13`, `19`, and the drift variants in the bug list)**
+   - **Not directly provable with single-file compile**, but likely same underlying issue:
+   - Root cause candidate: map iteration order is emitted directly in binary-affecting paths (IR serialization and interface dispatch table generation) without key sorting; this can perturb emitted order and cause stage drift.
+
+5. **`err.Error()` and helper-returned interface calls (`03`, `17`)**
+   - Standalone scaffolds compiled in current tree, so the original failures appear to be **shape-sensitive within specific selfhost paths**, not a universal parse failure.
+   - Root cause candidate: interface-call lowering and method-table state become fragile when the receiver type information is lost through helper boundaries in larger driver code.
+
+6. **Frontend/backend interface helper crashes (`01`, `14`) and assertion path (`18`)**
+   - Standalone scaffolds compiled in current tree, indicating these are **context-dependent selfhost codegen instability bugs** rather than always-on frontend parse errors.
+   - Root cause candidate: interaction between interface/type-assertion helperized control flow and non-deterministic backend symbol/type metadata ordering.
+
+## Source code evidence for the root causes
+
+- Receiver parser requires identifier first:
+  - `parseFuncDecl` + `parseReceiver` receiver flow in `std/compiler/frontend/go/parser.go`.
+- Function-call name resolution returns local identifiers (not lowered indirect calls):
+  - `resolveCallName` in `std/compiler/frontend/go/compiler.go`.
+- Unknown selector call target is emitted on unresolved receiver type:
+  - `resolveCallName` in `std/compiler/frontend/go/compiler.go`.
+- Non-deterministic map iteration in binary emission:
+  - `writeIRBinary` iterates maps without sorting in `std/compiler/binary/ir_binary_codec.go`.
+- Non-deterministic map iteration in interface dispatch table build:
+  - interface dispatch entry generation from `TypeIDs` map in `std/compiler/backend/x64/backend_x64.go`.

--- a/tests/compiler_bugs_repros/results/compile_results.txt
+++ b/tests/compiler_bugs_repros/results/compile_results.txt
@@ -1,0 +1,87 @@
+== 01_backend_interface_helper_call target=c/64 ==
+PASS
+
+== 02_unnamed_receiver_rejected target=linux/amd64 ==
+FAIL
+parse errors in tests/compiler_bugs_repros/02_unnamed_receiver_rejected.go:
+  expected type, got ) at line 5
+  expected ), got IDENT(M) at line 5 col 10
+  expected IDENT, got ( at line 5 col 11
+  expected (, got ) at line 5 col 12
+  expected type, got { at line 5
+  expected type, got } at line 5
+  expected type, got ; at line 7
+  expected (, got IDENT(main) at line 7 col 6
+  expected type, got ( at line 7
+  expected type, got { at line 7
+  expected type, got { at line 8
+
+== 03_error_method_on_helper_result target=linux/amd64 ==
+PASS
+
+== 04_driver_options_threading_instability target=linux/amd64 ==
+PASS
+
+== 05_function_typed_parameter_call target=linux/amd64 ==
+FAIL
+error: 1 unresolved calls:
+  fn
+codegen error: 1 unresolved calls
+
+== 06_apply_restore_wrapper_drift target=linux/amd64 ==
+FAIL
+error: 1 unresolved calls:
+  fn
+codegen error: 1 unresolved calls
+
+== 07_frontend_options_conversion_helper target=linux/amd64 ==
+PASS
+
+== 08_backend_map_interface_registry target=linux/amd64 ==
+FAIL
+error: 1 unresolved calls:
+  unknown
+codegen error: 1 unresolved calls
+
+== 09_wasm_cross_selfhost_global_init_drift target=linux/amd64 ==
+PASS
+
+== 10_embed_name_data_mismatch target=linux/amd64 ==
+PASS
+
+== 11_embed_walk_before_embedded_fs target=linux/amd64 ==
+PASS
+
+== 12_native_backend_callback_helpers target=linux/amd64 ==
+FAIL
+error: 3 unresolved calls:
+  fn
+codegen error: 3 unresolved calls
+
+== 13_collapsed_native_generator_entrypoint target=linux/amd64 ==
+PASS
+
+== 14_frontend_interface_dispatch_crash target=linux/amd64 ==
+PASS
+
+== 15_function_value_dispatch_map target=linux/amd64 ==
+FAIL
+error: 1 unresolved calls:
+  gen
+codegen error: 1 unresolved calls
+
+== 16_backend_interface_registry_crash target=linux/amd64 ==
+FAIL
+error: 1 unresolved calls:
+  unknown
+codegen error: 1 unresolved calls
+
+== 17_error_method_in_runmode_helper target=linux/amd64 ==
+PASS
+
+== 18_exiterror_assertion_helper target=linux/amd64 ==
+PASS
+
+== 19_possible_targets_relocation target=linux/amd64 ==
+PASS
+


### PR DESCRIPTION
### Motivation
- Provide isolated, minimal Go scaffolds for each entry in `COMPILER_BUGS` so each failure shape can be investigated without tripping unrelated parse/stdlib dependencies. 
- Capture observed failure classes (parser unnamed-receiver, unresolved indirect calls, interface dispatch `unknown`, and stage-drift candidates) and surface likely root causes to guide fixes.

### Description
- Add a new directory `tests/compiler_bugs_repros/` with 19 minimal `package main` repro files that preserve the problematic code shapes and avoid importing the stdlib (so they do not introduce unrelated failure noise). 
- Add `tests/compiler_bugs_repros/README.md` describing the manual nature of these repros and `ROOT_CAUSE_ANALYSIS.md` documenting a tested compile matrix and grouped root-cause hypotheses. 
- Add `tests/compiler_bugs_repros/results/compile_results.txt` recording the compile-matrix outputs and refine several repros to use local types and named receivers (except the explicit unnamed-receiver parser repro) so each scaffold isolates its intended shape. 
- Format the repro files with `gofmt -w tests/compiler_bugs_repros/*.go` while leaving full-tree `go fmt ./...` untouched because it fails on a preexisting parse error in `std/compiler/main_no_frontend.go`.

### Testing
- Built the tool runner with `go build -o build/build ./tools` and rebuilt the compiler with `./build/build build`, both succeeding. 
- Ran a compile matrix using `./build/rtg` over the repro set (01 compiled with `-T c/64`, others with `-T linux/amd64`) and recorded results in `tests/compiler_bugs_repros/results/compile_results.txt`. 
- Observed repro outcomes: `PASS` for 01,03,04,07,09,10,11,13,14,17,18,19 and `FAIL` for 02 (parser unnamed-receiver), 05/06/12/15 (unresolved indirect/callback calls), and 08/16 (interface dispatch unresolved `unknown`). 
- Attempted `go fmt ./...` as requested but it fails due to an existing parse error in `std/compiler/main_no_frontend.go`; the repro files themselves were formatted successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699968b174288333941bf45d8aaabd36)