### PR TITLE
compiler: fix embedded runtime lookup and clean panic exits

### DIFF
--- a/std/compiler/backend/i386/backend_linux_i386.go
+++ b/std/compiler/backend/i386/backend_linux_i386.go
@@ -154,7 +154,8 @@ func (g *CodeGen) compilePanic_linux386() {
 	g.popR32(REG32_EBP)
 	g.popR32(REG32_EDI)
 
-	// Crash: null dereference -> SIGSEGV
-	g.xorRR32(REG32_EAX, REG32_EAX)
-	g.loadMem32(REG32_EAX, REG32_EAX, 0) // mov eax, [eax] -> segfault
+	// exit(2): return a clean panic status instead of deliberate SIGSEGV.
+	g.emitMovRegImm32(REG32_EBX, 2) // status
+	g.emitMovRegImm32(REG32_EAX, 1) // SYS_exit
+	g.emitInt80()
 }

--- a/std/compiler/backend/x64/backend_linux_x64.go
+++ b/std/compiler/backend/x64/backend_linux_x64.go
@@ -120,7 +120,8 @@ func (g *CodeGen) compilePanic() {
 	g.emitBytes(0x0f, 0x05)                   // syscall
 	g.emitBytes(0x48, 0x83, 0xc4, 0x08)       // add rsp, 8         ; pop the '\n'
 
-	// Crash: null dereference → SIGSEGV
-	g.emitBytes(0x48, 0x31, 0xc0) // xor rax, rax
-	g.emitBytes(0x48, 0x8b, 0x00) // mov rax, [rax]
+	// Exit(2): align with Go panic process status instead of deliberate SIGSEGV.
+	g.emitBytes(0xbf, 0x02, 0x00, 0x00, 0x00) // mov edi, 2
+	g.emitBytes(0xb8, 0x3c, 0x00, 0x00, 0x00) // mov eax, 60  ; SYS_exit
+	g.emitBytes(0x0f, 0x05)                   // syscall
 }

--- a/std/compiler/frontend/go/parser_go.go
+++ b/std/compiler/frontend/go/parser_go.go
@@ -1,4 +1,4 @@
-//go:build !rtg || no_embed_std
+//go:build no_embed_std
 
 package frontend
 

--- a/std/compiler/frontend/go/parser_rtg.go
+++ b/std/compiler/frontend/go/parser_rtg.go
@@ -1,4 +1,4 @@
-//go:build rtg && !no_embed_std
+//go:build !no_embed_std
 
 package frontend
 
@@ -7,26 +7,43 @@ import (
 )
 
 func (p *Preprocessor) parsePackageFromEmbed(importPath string) *Package {
-	// List files in the embedded std directory for this import path
-	files := stdlib.ReadDirFromEmbed(importPath)
-	if len(files) == 0 {
+	// Enumerate all embedded files and filter by package prefix. Some embed
+	// runtimes are unreliable for non-dot walk roots.
+	names, data := stdlib.WalkEmbedFromFS(".")
+	if len(names) == 0 {
 		return nil
 	}
+	contentsByPath := make(map[string]string, len(names))
+	for i := 0; i < len(names) && i < len(data); i++ {
+		contentsByPath[names[i]] = data[i]
+	}
 
-	// Filter and sort .go files
+	// Filter and sort .go files in this package directory.
 	var goFiles []string
-	i := 0
-	for i < len(files) {
-		name := files[i]
-		if isGoFile(name) {
-			content := stdlib.ReadFileFromEmbed(importPath + "/" + name)
-			if p.shouldIncludeContent(content, name) {
-				goFiles = append(goFiles, name)
-			}
+	for _, full := range names {
+		if len(full) <= len(importPath)+1 {
+			continue
 		}
-		i = i + 1
+		if full[0:len(importPath)] != importPath || full[len(importPath)] != '/' {
+			continue
+		}
+		name := full[len(importPath)+1:]
+		// Ignore nested files; package files must be direct children.
+		if len(name) == 0 || stringsIndexByte(name, '/') >= 0 {
+			continue
+		}
+		if !isGoFile(name) {
+			continue
+		}
+		content := contentsByPath[full]
+		if p.shouldIncludeContent(content, name) {
+			goFiles = append(goFiles, name)
+		}
 	}
 	sortStrings(goFiles)
+	if len(goFiles) == 0 {
+		return nil
+	}
 
 	pkg := &Package{
 		Path:    importPath,
@@ -34,10 +51,10 @@ func (p *Preprocessor) parsePackageFromEmbed(importPath string) *Package {
 		Symbols: make(map[string]*Symbol),
 	}
 
-	i = 0
+	i := 0
 	for i < len(goFiles) {
 		name := goFiles[i]
-		content := stdlib.ReadFileFromEmbed(importPath + "/" + name)
+		content := contentsByPath[importPath+"/"+name]
 		node := parseSource(importPath+"/"+name, content)
 		if node != nil {
 			if pkg.Name == "" {
@@ -54,4 +71,15 @@ func (p *Preprocessor) parsePackageFromEmbed(importPath string) *Package {
 
 	pkg.Imports = collectImports(pkg)
 	return pkg
+}
+
+func stringsIndexByte(s string, c byte) int {
+	i := 0
+	for i < len(s) {
+		if s[i] == c {
+			return i
+		}
+		i = i + 1
+	}
+	return -1
 }

--- a/std/compiler/stdlib/stdlib_noembed.go
+++ b/std/compiler/stdlib/stdlib_noembed.go
@@ -9,3 +9,11 @@ func HasEmbeddedStd() bool {
 func WalkEmbedFromFS(embedDir string) ([]string, []string) {
 	return nil, nil
 }
+
+func ReadDirFromEmbed(path string) []string {
+	return nil
+}
+
+func ReadFileFromEmbed(path string) string {
+	return ""
+}

--- a/std/compiler/stdlib/stdlib_rtg.go
+++ b/std/compiler/stdlib/stdlib_rtg.go
@@ -6,7 +6,7 @@ import (
 	"embed"
 )
 
-//go:embed ..
+//go:embed ../..
 var embeddedStd embed.FS
 
 func HasEmbeddedStd() bool {


### PR DESCRIPTION
## Summary
- fix embedded stdlib packaging to include full  tree for self-hosted/WASM-produced compiler binaries
- fix embedded package discovery to walk from  and prefix-filter by import path (robust in clean environments)
- keep no-embed stubs aligned for parser/stdlib embed helper symbols
- change linux panic lowering to terminate via  instead of deliberate SIGSEGV on:
  - x64 backend
  - i386 backend

## Why
- WASM-produced native compiler binaries failed in clean directories with 
- panic behavior should return a clean nonzero process status, not crash via SIGSEGV

## Validation
- === build ===
running /bin/sh -c go build -o build/rtg ./std/compiler/
=== crosscompile-wasm-native ===
running /bin/sh -c ./build/rtg -T wasi/wasm32 -o build/cross_stage1.wasm ./std/compiler/
running /bin/sh -c wasmtime --dir=. build/cross_stage1.wasm -T linux/amd64 -o build/cross_stage2 ./std/compiler/
running /bin/sh -c chmod +x build/cross_stage2
running /bin/sh -c ./build/cross_stage2 -h >/dev/null
running /bin/sh -c ./build/cross_stage2 -o build/cross_smoke tests/func_variadic.go
running /bin/sh -c ./build/cross_smoke >/dev/null
running /bin/sh -c ./build/cross_stage2 -o build/cross_stage3 ./std/compiler/
running /bin/sh -c ./build/cross_stage3 -o build/cross_stage4 ./std/compiler/
running /bin/sh -c ./build/cross_stage3 -h >/dev/null
running /bin/sh -c ./build/cross_stage4 -h >/dev/null
running /bin/sh -c cmp build/cross_stage3 build/cross_stage4 && echo PASS: wasm->native cross-compile OK
- clean temp directory (no source tree in cwd) with :
  - compile/run  succeeds
  - compile/run  exits with status 
- === build ===
running /bin/sh -c go build -o build/rtg ./std/compiler/
=== selfhost ===
running /bin/sh -c ./build/rtg -o build/stage1 ./std/compiler/
running /bin/sh -c ./build/stage1 -o build/stage_out ./std/compiler/ && mv build/stage_out build/stage2
running /bin/sh -c ./build/stage2 -o build/stage_out ./std/compiler/ && mv build/stage_out build/stage3
running /bin/sh -c cmp build/stage2 build/stage3 && echo PASS: self-hosting OK
PASS: self-hosting OK
- === build ===
running /bin/sh -c go build -o build/rtg ./std/compiler/
=== test-fullcompiler-rtg ===
PASS: rtg/04_defer_no_effect
PASS: rtg/07_func_literal_ice
PASS: rtg/08_call_func_value
PASS: rtg/09_method_value
PASS: rtg/10_goto_label
PASS: rtg/12_switch_init_stmt
PASS: rtg/14_fixed_array_type
PASS: rtg/15_array_ellipsis_len
PASS: rtg/16_type_alias
PASS: rtg/17_local_type_decl
PASS: rtg/18_full_slice_expr
PASS: rtg/21_binary_octal_literal
PASS: rtg/22_numeric_underscore
PASS: rtg/26_range_string_utf8
PASS: rtg/27_rune_literal_utf8
PASS: rtg/28_int_to_string_conversion
PASS: rtg/29_bare_return_named_results
PASS: rtg/30_builtin_new
PASS: rtg/34_import_alias
PASS: rtg/35_blank_import
PASS: rtg/36_closure_capture_assignment
PASS: rtg/37_asm_double_amd64
PASS: rtg/38_asm_param_balance_amd64
PASS: rtg/39_asm_multi_param_math_amd64
PASS: rtg/40_asm_call_two_args_amd64
PASS: rtg/41_asm_call_chain_native_amd64
PASS: rtg/42_asm_large_imm_amd64
PASS: rtg/43_asm_negative_imm_amd64
SKIP: rtg/44_asm_double_386 (386-only test)
SKIP: rtg/45_asm_call_386 (386-only test)
SKIP: rtg/46_asm_double_arm64 (arm64-only test)
SKIP: rtg/47_asm_call_arm64 (arm64-only test)
PASS: rtg/composite_lit
PASS: rtg/comptime_method
PASS: rtg/const_basic
PASS: rtg/const_iota
PASS: rtg/defer_basic
PASS: rtg/flow_break_continue
PASS: rtg/flow_for
PASS: rtg/flow_if
PASS: rtg/flow_range
PASS: rtg/flow_switch
PASS: rtg/flow_switch_init_stmt
PASS: rtg/func_basic
PASS: rtg/func_closure
PASS: rtg/func_method
PASS: rtg/func_multireturn
PASS: rtg/func_named_return
PASS: rtg/func_recursion
PASS: rtg/func_variadic
PASS: rtg/global_var
PASS: rtg/iface_basic
PASS: rtg/iface_empty
PASS: rtg/iface_error
PASS: rtg/iface_multi
PASS: rtg/iface_typeassert
PASS: rtg/iface_typeswitch
PASS: rtg/import_alias
PASS: rtg/import_blank
PASS: rtg/init_func
PASS: rtg/local_type_decl
PASS: rtg/map_basic
PASS: rtg/map_comma_ok
PASS: rtg/map_literal
PASS: rtg/map_range
PASS: rtg/map_range_map_values
PASS: rtg/map_types
PASS: rtg/multiassign
PASS: rtg/ops_arithmetic
PASS: rtg/ops_assignment
PASS: rtg/ops_bitwise
PASS: rtg/ops_comparison
PASS: rtg/ops_precedence
PASS: rtg/ops_unary
PASS: rtg/panic_basic
PASS: rtg/pointer_basic
PASS: rtg/recover_basic
PASS: rtg/scope_shadow
PASS: rtg/slice_append
PASS: rtg/slice_basic
PASS: rtg/slice_nested
PASS: rtg/slice_ops
PASS: rtg/slice_range
PASS: rtg/string_builder
PASS: rtg/struct_basic
PASS: rtg/struct_embedding
PASS: rtg/struct_nested
PASS: rtg/struct_pointer
PASS: rtg/type_alias
PASS: rtg/type_alias_equals
PASS: rtg/type_convert
PASS: rtg/type_convert_int64
PASS: rtg/types_bool
PASS: rtg/types_int
PASS: rtg/types_nil
PASS: rtg/types_rune
PASS: rtg/types_string