### PR TITLE
compiler: fix embedded runtime resolution and panic exit semantics

### DIFF
--- a/std/compiler/backend/i386/backend_linux_i386.go
+++ b/std/compiler/backend/i386/backend_linux_i386.go
@@ -154,7 +154,8 @@ func (g *CodeGen) compilePanic_linux386() {
 	g.popR32(REG32_EBP)
 	g.popR32(REG32_EDI)
 
-	// Crash: null dereference -> SIGSEGV
-	g.xorRR32(REG32_EAX, REG32_EAX)
-	g.loadMem32(REG32_EAX, REG32_EAX, 0) // mov eax, [eax] -> segfault
+	// exit(2): return a clean panic status instead of deliberate SIGSEGV.
+	g.emitMovRegImm32(REG32_EBX, 2) // status
+	g.emitMovRegImm32(REG32_EAX, 1) // SYS_exit
+	g.emitInt80()
 }

--- a/std/compiler/backend/x64/backend_linux_x64.go
+++ b/std/compiler/backend/x64/backend_linux_x64.go
@@ -120,7 +120,8 @@ func (g *CodeGen) compilePanic() {
 	g.emitBytes(0x0f, 0x05)                   // syscall
 	g.emitBytes(0x48, 0x83, 0xc4, 0x08)       // add rsp, 8         ; pop the '\n'
 
-	// Crash: null dereference → SIGSEGV
-	g.emitBytes(0x48, 0x31, 0xc0) // xor rax, rax
-	g.emitBytes(0x48, 0x8b, 0x00) // mov rax, [rax]
+	// Exit(2): align with Go panic process status instead of deliberate SIGSEGV.
+	g.emitBytes(0xbf, 0x02, 0x00, 0x00, 0x00) // mov edi, 2
+	g.emitBytes(0xb8, 0x3c, 0x00, 0x00, 0x00) // mov eax, 60  ; SYS_exit
+	g.emitBytes(0x0f, 0x05)                   // syscall
 }

--- a/std/compiler/frontend/go/parser_go.go
+++ b/std/compiler/frontend/go/parser_go.go
@@ -1,4 +1,4 @@
-//go:build !rtg || no_embed_std
+//go:build no_embed_std
 
 package frontend
 

--- a/std/compiler/frontend/go/parser_rtg.go
+++ b/std/compiler/frontend/go/parser_rtg.go
@@ -1,4 +1,4 @@
-//go:build rtg && !no_embed_std
+//go:build !no_embed_std
 
 package frontend
 
@@ -7,26 +7,43 @@ import (
 )
 
 func (p *Preprocessor) parsePackageFromEmbed(importPath string) *Package {
-	// List files in the embedded std directory for this import path
-	files := stdlib.ReadDirFromEmbed(importPath)
-	if len(files) == 0 {
+	// Enumerate all embedded files and filter by package prefix. Some embed
+	// runtimes are unreliable for non-dot walk roots.
+	names, data := stdlib.WalkEmbedFromFS(".")
+	if len(names) == 0 {
 		return nil
 	}
+	contentsByPath := make(map[string]string, len(names))
+	for i := 0; i < len(names) && i < len(data); i++ {
+		contentsByPath[names[i]] = data[i]
+	}
 
-	// Filter and sort .go files
+	// Filter and sort .go files in this package directory.
 	var goFiles []string
-	i := 0
-	for i < len(files) {
-		name := files[i]
-		if isGoFile(name) {
-			content := stdlib.ReadFileFromEmbed(importPath + "/" + name)
-			if p.shouldIncludeContent(content, name) {
-				goFiles = append(goFiles, name)
-			}
+	for _, full := range names {
+		if len(full) <= len(importPath)+1 {
+			continue
 		}
-		i = i + 1
+		if full[0:len(importPath)] != importPath || full[len(importPath)] != '/' {
+			continue
+		}
+		name := full[len(importPath)+1:]
+		// Ignore nested files; package files must be direct children.
+		if len(name) == 0 || stringsIndexByte(name, '/') >= 0 {
+			continue
+		}
+		if !isGoFile(name) {
+			continue
+		}
+		content := contentsByPath[full]
+		if p.shouldIncludeContent(content, name) {
+			goFiles = append(goFiles, name)
+		}
 	}
 	sortStrings(goFiles)
+	if len(goFiles) == 0 {
+		return nil
+	}
 
 	pkg := &Package{
 		Path:    importPath,
@@ -34,10 +51,10 @@ func (p *Preprocessor) parsePackageFromEmbed(importPath string) *Package {
 		Symbols: make(map[string]*Symbol),
 	}
 
-	i = 0
+	i := 0
 	for i < len(goFiles) {
 		name := goFiles[i]
-		content := stdlib.ReadFileFromEmbed(importPath + "/" + name)
+		content := contentsByPath[importPath+"/"+name]
 		node := parseSource(importPath+"/"+name, content)
 		if node != nil {
 			if pkg.Name == "" {
@@ -54,4 +71,15 @@ func (p *Preprocessor) parsePackageFromEmbed(importPath string) *Package {
 
 	pkg.Imports = collectImports(pkg)
 	return pkg
+}
+
+func stringsIndexByte(s string, c byte) int {
+	i := 0
+	for i < len(s) {
+		if s[i] == c {
+			return i
+		}
+		i = i + 1
+	}
+	return -1
 }

--- a/std/compiler/stdlib/stdlib_noembed.go
+++ b/std/compiler/stdlib/stdlib_noembed.go
@@ -9,3 +9,11 @@ func HasEmbeddedStd() bool {
 func WalkEmbedFromFS(embedDir string) ([]string, []string) {
 	return nil, nil
 }
+
+func ReadDirFromEmbed(path string) []string {
+	return nil
+}
+
+func ReadFileFromEmbed(path string) string {
+	return ""
+}

--- a/std/compiler/stdlib/stdlib_rtg.go
+++ b/std/compiler/stdlib/stdlib_rtg.go
@@ -6,7 +6,7 @@ import (
 	"embed"
 )
 
-//go:embed ..
+//go:embed ../..
 var embeddedStd embed.FS
 
 func HasEmbeddedStd() bool {


### PR DESCRIPTION
## Summary
- fix embedded stdlib/runtime resolution for standalone compiler binaries
- make panic termination exit with status `2` instead of deliberate SIGSEGV on Linux backends
- keep embedded-vs-no-embed parser selection driven by `no_embed_std`

## Key Changes
- `std/compiler/stdlib/stdlib_rtg.go`
  - widen embed root from `..` to `../..` so embedded FS includes runtime package sources
- `std/compiler/frontend/go/parser_rtg.go`
  - use `//go:build !no_embed_std`
  - rework embedded package walking to scan from `.` and filter by import path prefix
- `std/compiler/frontend/go/parser_go.go`
  - switch to `//go:build no_embed_std`
- `std/compiler/stdlib/stdlib_noembed.go`
  - provide no-embed stubs for `ReadDirFromEmbed` and `ReadFileFromEmbed`
- `std/compiler/backend/x64/backend_linux_x64.go`
  - panic path now exits with syscall `exit(2)`
- `std/compiler/backend/i386/backend_linux_i386.go`
  - panic path now exits with syscall `exit(2)`

## Validation
- `go build -o build/rtg ./std/compiler/`
- `go build -o build/build ./tools/build.go`
- `./build/build crosscompile-wasm-native`
- `./build/build test-fullcompiler-rtg`
- `./build/build selfhost`

## Clean temp-dir verification
Using wasm-produced compiler binary in a temp directory with no source-tree access:
- `package main; func main(){}` compiles and runs successfully
- `package main; func main(){ panic(10) }` exits with status `2` (no SIGSEGV)
