### PR TITLE
Stamp web compiler builds with git hash via -D

### DIFF
--- a/std/compiler/common/common.go
+++ b/std/compiler/common/common.go
@@ -10,6 +10,7 @@ type Target struct {
 	CModel                int    // 16/32/64 when targetBackend==c
 	WordSize              int    // word size in bytes
 	BuildTags             []string
+	Defines               map[string]string
 	CompilerDebug         bool
 	StripBinary           bool
 	StdlibIncludePaths    []string

--- a/std/compiler/frontend/go/compiler.go
+++ b/std/compiler/frontend/go/compiler.go
@@ -103,8 +103,8 @@ type Compiler struct {
 	inComptimeFunc       bool
 	inIfInit             bool
 	ifInitLeakedNames    map[string]bool
-	assembleFuncs       map[string]assembleInfo
-	inAssembleBuilder   bool
+	assembleFuncs        map[string]assembleInfo
+	inAssembleBuilder    bool
 }
 
 func (c *Compiler) dotJoin(a string, b string) string {
@@ -1380,6 +1380,11 @@ func (c *Compiler) compileGlobalInits(pkg *Package) {
 		if !ok {
 			continue
 		}
+		if defineValue, ok := c.lookupDefineValue(qname, node.Name); ok {
+			c.emit(ir.Inst{Op: ir.OP_CONST_STR, Name: encodeStringLiteral(defineValue)})
+			c.emit(ir.Inst{Op: ir.OP_GLOBAL_SET, Arg: gidx})
+			continue
+		}
 		c.compileExpr(node.X)
 		c.emit(ir.Inst{Op: ir.OP_GLOBAL_SET, Arg: gidx})
 	}
@@ -1400,6 +1405,19 @@ func (c *Compiler) compileGlobalInits(pkg *Package) {
 	}
 	c.irmod.Funcs = append(c.irmod.Funcs, f)
 	c.curFunc = nil
+}
+
+func (c *Compiler) lookupDefineValue(qualifiedName string, shortName string) (string, bool) {
+	if c == nil || c.target == nil || c.target.Defines == nil {
+		return "", false
+	}
+	if v, ok := c.target.Defines[qualifiedName]; ok {
+		return v, true
+	}
+	if v, ok := c.target.Defines[shortName]; ok {
+		return v, true
+	}
+	return "", false
 }
 
 func (c *Compiler) compileEmbedInit(pkg *Package, gidx int, pattern string) {

--- a/std/compiler/main.go
+++ b/std/compiler/main.go
@@ -27,6 +27,7 @@ var compileTarget = common.Target{
 	CModel:                0,                // 16/32/64 when targetBackend==c
 	WordSize:              defaultPtrSize(), // word size in bytes
 	BuildTags:             []string{},
+	Defines:               map[string]string{},
 	CompilerDebug:         false,
 	StripBinary:           false,
 	StdlibIncludePaths:    []string{},
@@ -145,12 +146,16 @@ func main() {
 	var extractStdlibDest string
 	var runMode bool
 	var stdinInput bool
+	var showVersion bool
 	var programArgs []string
 	i := 1
 	for i < len(os.Args) {
 		if os.Args[i] == "-h" || os.Args[i] == "--help" {
 			printHelp(os.Args[0], os.Stdout)
 			os.Exit(0)
+		} else if os.Args[i] == "-version" || os.Args[i] == "--version" {
+			showVersion = true
+			i = i + 1
 		} else if os.Args[i] == "-run" {
 			runMode = true
 			i = i + 1
@@ -259,6 +264,15 @@ func main() {
 		} else if os.Args[i] == "-tags" && i+1 < len(os.Args) {
 			extraTags = os.Args[i+1]
 			i = i + 2
+		} else if os.Args[i] == "-D" && i+1 < len(os.Args) {
+			key, value, ok := parseDefineArg(os.Args[i+1])
+			if !ok {
+				fmt.Fprintf(os.Stderr, "invalid -D value %q: expected key=value\n", os.Args[i+1])
+				runCleanup()
+				os.Exit(1)
+			}
+			compileTarget.Defines[key] = value
+			i = i + 2
 		} else if os.Args[i] == "-include" && i+1 < len(os.Args) {
 			val := common.NormalizePath(os.Args[i+1])
 			if !compileTarget.StdlibIncludeExplicit {
@@ -295,6 +309,10 @@ func main() {
 			entryFiles = append(entryFiles, common.NormalizePath(os.Args[i]))
 			i = i + 1
 		}
+	}
+	if showVersion {
+		fmt.Fprintf(os.Stdout, "%s\n", compilerStamp())
+		os.Exit(0)
 	}
 	if stdinInput {
 		if fromIRBinaryPath != "" {
@@ -369,6 +387,11 @@ func main() {
 	compileTarget.BuildTags = append(compileTarget.BuildTags, "rtg")
 	if ir.SizeAnalysisPath != "" {
 		compileTarget.StripBinary = true
+	}
+	if compilerBuildGitHash != "" {
+		if _, ok := compileTarget.Defines["main.compilerBuildGitHash"]; !ok {
+			compileTarget.Defines["main.compilerBuildGitHash"] = compilerBuildGitHash
+		}
 	}
 	traceExit(10)
 
@@ -596,6 +619,7 @@ func printHelp(program string, out *os.File) {
 	fmt.Fprintf(out, "  -o <path>              Output path (default: output)\n")
 	fmt.Fprintf(out, "  -T <target>            Target triple or backend mode\n")
 	fmt.Fprintf(out, "  -tags <a,b,c>          Extra build tags\n")
+	fmt.Fprintf(out, "  -D <key=value>         Set a string value for a global variable symbol\n")
 	fmt.Fprintf(out, "  -include <path|->      Add stdlib search root; first -include disables default embedded stdlib, -include - re-enables it\n")
 	fmt.Fprintf(out, "  -extract-stdlib <dest> Extract standard library files into destination directory and exit\n")
 	fmt.Fprintf(out, "  -parse-only            Parse and resolve imports only (no codegen)\n")
@@ -606,6 +630,7 @@ func printHelp(program string, out *os.File) {
 	fmt.Fprintf(out, "  -list-build-tags <p>   Write discovered build tags (one per line)\n")
 	fmt.Fprintf(out, "  -run                   Compile and run the output binary\n")
 	fmt.Fprintf(out, "  -size-analysis <path>  Write per-function size analysis JSON\n")
+	fmt.Fprintf(out, "  -version, --version    Print compiler stamp\n")
 	fmt.Fprintf(out, "  -debug                 Enable compiler debug logging\n")
 	fmt.Fprintf(out, "  -strip, -s             Strip symbol/debug metadata from native binaries\n")
 	fmt.Fprintf(out, "  -h, --help             Show this help\n")
@@ -614,6 +639,19 @@ func printHelp(program string, out *os.File) {
 	for _, target := range possibleTargets() {
 		fmt.Fprintf(out, "  %s\n", target)
 	}
+}
+
+func parseDefineArg(raw string) (string, string, bool) {
+	eq := strings.Index(raw, "=")
+	if eq <= 0 {
+		return "", "", false
+	}
+	key := raw[0:eq]
+	value := raw[eq+1:]
+	if key == "" {
+		return "", "", false
+	}
+	return key, value, true
 }
 
 func possibleTargets() []string {

--- a/std/compiler/stamp.go
+++ b/std/compiler/stamp.go
@@ -1,0 +1,11 @@
+package main
+
+// compilerBuildGitHash can be set at compile time via -D main.compilerBuildGitHash=<hash>.
+var compilerBuildGitHash = ""
+
+func compilerStamp() string {
+	if compilerBuildGitHash == "" {
+		return "unknown"
+	}
+	return compilerBuildGitHash
+}

--- a/web/build.sh
+++ b/web/build.sh
@@ -11,7 +11,11 @@ fi
 
 # Step 2: Compile WASM compiler (without embedded std to reduce size)
 echo "Compiling WASM compiler..."
-./build/rtg -T wasi/wasm32 -tags no_embed_std -o web/compiler.wasm ./std/compiler/
+GIT_HASH="$(git rev-parse --short=12 HEAD 2>/dev/null || true)"
+if [ -z "$GIT_HASH" ]; then
+  GIT_HASH="unknown"
+fi
+./build/rtg -T wasi/wasm32 -tags no_embed_std -D "main.compilerBuildGitHash=$GIT_HASH" -o web/compiler.wasm ./std/compiler/
 echo "Generated web/compiler.wasm ($(wc -c < web/compiler.wasm) bytes)"
 
 # Step 3: Bundle everything into a single playground.html

--- a/web/index.html
+++ b/web/index.html
@@ -1044,7 +1044,7 @@
 
   <div id="statusbar">
     <span id="status">Ready</span>
-    <span class="status-right">RTG Compiler</span>
+    <span id="compiler-stamp" class="status-right">RTG Compiler</span>
   </div>
 
   <!-- Tab management (runs before playground.js module) -->

--- a/web/playground.js
+++ b/web/playground.js
@@ -37,6 +37,7 @@ const tagsPanel = document.getElementById("tags-panel");
 const tagsList = document.getElementById("tags-list");
 const tagsMeta = document.getElementById("tags-meta");
 const btnRescanTags = document.getElementById("btn-rescan-tags");
+const compilerStampEl = document.getElementById("compiler-stamp");
 
 // --- Init ---
 function init() {
@@ -413,10 +414,30 @@ async function loadCompilerModule() {
     }
     compilerModule = await WebAssembly.compileStreaming(fetch("compiler.wasm"));
     setStatus("Ready");
+    await loadCompilerStamp();
     discoverBuildTags();
   } catch (e) {
     setStatus("Error loading compiler: " + e.message);
   }
+}
+
+async function loadCompilerStamp() {
+  if (!compilerModule || !compilerStampEl) return;
+  try {
+    const fs = new VirtualFS();
+    let stamp = "";
+    const exitCode = await runCompilerInWasi(fs, ["rtg", "-version"], {
+      onStdout: (data) => {
+        stamp += new TextDecoder().decode(data);
+      },
+    });
+    const clean = stamp.trim();
+    if (exitCode === 0 && clean.length > 0) {
+      compilerStampEl.textContent = "RTG " + clean;
+      return;
+    }
+  } catch {}
+  compilerStampEl.textContent = "RTG unknown";
 }
 
 async function runCompilerInWasi(fs, args, handlers = {}) {


### PR DESCRIPTION
## Summary
- add compiler stamp variable in `std/compiler` and `-version` flag to print it
- add new `-D key=value` compiler flag and frontend define override for global init symbols
- auto-propagate compiler stamp when compiling `std/compiler` by defaulting `main.compilerBuildGitHash` from the running compiler's stamp
- wire `web/build.sh` to pass `-D main.compilerBuildGitHash=<git rev-parse --short=12 HEAD>` when producing `web/compiler.wasm`
- display detected compiler stamp in the playground status bar (bottom-right) by invoking the wasm compiler with `-version`

## Validation
- `./tools/build.go test`
- `bash web/build.sh`
- manual propagation check:
  - `./build/rtg -D main.compilerBuildGitHash=abc123stamp -o /tmp/rtg_stamp1 ./std/compiler/`
  - `/tmp/rtg_stamp1 -version` -> `abc123stamp`
  - `/tmp/rtg_stamp1 -o /tmp/rtg_stamp2 ./std/compiler/`
  - `/tmp/rtg_stamp2 -version` -> `abc123stamp`
