### PR TITLE
Improve web playground examples and WASM smoke coverage

### DIFF
--- a/.github/workflows/selfhost.yml
+++ b/.github/workflows/selfhost.yml
@@ -72,6 +72,9 @@ jobs:
           node web/bundle.js
           node web/node-wasm-selfhost-smoke.mjs --platform "${{ matrix.target }}"
 
+      - name: Webpage bundled examples smoke (Node)
+        run: node web/node-compile-examples-smoke.mjs
+
       - name: Native self-hosting (3-stage)
         run: |
           ./build/rtg${{ matrix.suffix }} -T ${{ matrix.target }} -o build/stage1${{ matrix.suffix }} ./std/compiler/

--- a/COMPILER_BUGS.md
+++ b/COMPILER_BUGS.md
@@ -23,25 +23,11 @@ Compiler bugs/limitations discovered while implementing stdlib extensions (`erro
 - `#29` `OFFSET+LOAD/STORE` folding currently causes wasm one-stage selfhost lag (`stage2 != stage3`, `stage3 == stage4`) without a wasm guard.
 - `#30` Non-void shared-return tail merge currently breaks wasm validation (`values remaining on stack at end of block`).
 - `#31` Panic-unwind slow-path outlining currently breaks wasm validation (`not enough arguments on the stack for drop`).
+- `#32` x64 Windows backend is missing lowering for runtime syscall intrinsics such as `SysRead`/`SysWrite`/`SysOpen`/`SysClose` (`ICE: unknown intrinsic 'SysRead' on GOOS=windows` when compiling stdlib-using Windows targets).
 
 ### Watch (not currently reproducible)
 - `#1` ICE in `compileGlobalInits` for package-scope initializers.
 - `#7` package-level `log` state runtime crash paths.
-
-### Resolved / Not Reproduced
-- `#2` interface method calls on chained struct fields.
-- `#3` chained receiver-field interface call in custom wrapper types.
-- `#4` type-asserted interface method dispatch.
-- `#5` chained temporary method call degrading to unresolved `unknown`.
-- `#6` bool-pointer deref typing in conditions/comparisons.
-- `#8` top-level function values unresolved in synthetic init wiring.
-- `#9` prior stdlib fixture callback-unresolved path.
-- `#10` `log.Logger.SetOutput` + write runtime crash.
-- `#11` deferred `testing.FinishTest`/`FinishBenchmark` panic-sentinel recovery.
-- `#12` WASM validator/semantic failures in extended stdlib fixtures (`54`/`55`).
-- `#13` DOS/8086 COMEMU OOM for `54_stdlib_cli_core`.
-- `#27` ARM64 operand-cache branch-edge desync (`OP_JMP_IF*`/`OP_JMP_*` could skip cache materialization and corrupt x28).
-- Historical DOS map/slice COMEMU failures from logs (`map_literal`, `slice_ops`, `map_comma_ok`, `map_range`, `map_types`, `slice_append`, `slice_nested`, `slice_range`) now PASS.
 
 ## Work Order
 

--- a/std/compiler/ir/zerocall.go
+++ b/std/compiler/ir/zerocall.go
@@ -50,9 +50,18 @@ func nextIRLabelID(code []Inst) int {
 	return maxLabel + 1
 }
 
+func appendUniqueString(list []string, value string) []string {
+	for i := 0; i < len(list); i++ {
+		if list[i] == value {
+			return list
+		}
+	}
+	return append(list, value)
+}
+
 func detectZeroCallCyclesVisit(
 	name string,
-	edges map[string]map[string]bool,
+	edges map[string][]string,
 	zeroCall map[string]bool,
 	state map[string]int,
 	stack *[]string,
@@ -65,11 +74,8 @@ func detectZeroCallCyclesVisit(
 	state[name] = 1
 	stackPos[name] = len(*stack)
 	*stack = append(*stack, name)
-	if nexts := edges[name]; nexts != nil {
-		nextNames := make([]string, 0, len(nexts))
-		for next := range nexts {
-			nextNames = append(nextNames, next)
-		}
+	if nexts := edges[name]; len(nexts) > 0 {
+		nextNames := append([]string{}, nexts...)
 		sort.Strings(nextNames)
 		for _, next := range nextNames {
 			if !zeroCall[next] {
@@ -96,7 +102,7 @@ func detectZeroCallCyclesVisit(
 	state[name] = 2
 }
 
-func detectZeroCallCycles(edges map[string]map[string]bool, zeroCall map[string]bool) []string {
+func detectZeroCallCycles(edges map[string][]string, zeroCall map[string]bool) []string {
 	state := make(map[string]int) // 0=unvisited, 1=visiting, 2=done
 	stack := []string{}
 	stackPos := make(map[string]int)
@@ -112,8 +118,8 @@ func detectZeroCallCycles(edges map[string]map[string]bool, zeroCall map[string]
 	return nil
 }
 
-func validateZeroCallFuncs(irmod *IRModule, funcIndex map[string]*IRFunc) (map[string]map[string]bool, []string) {
-	edges := make(map[string]map[string]bool)
+func validateZeroCallFuncs(irmod *IRModule, funcIndex map[string]*IRFunc) (map[string][]string, []string) {
+	edges := make(map[string][]string)
 	var errs []string
 
 	for _, name := range sortedStringKeys(irmod.ZeroCallFuncs) {
@@ -132,22 +138,19 @@ func validateZeroCallFuncs(irmod *IRModule, funcIndex map[string]*IRFunc) (map[s
 				errs = append(errs, fmt.Sprintf("zerocall function %s uses intrinsic call %s (unsupported)", name, inst.Name))
 			case OP_IFACE_CALL:
 				errs = append(errs, fmt.Sprintf("zerocall function %s uses interface dispatch %s (unsupported)", name, inst.Name))
-			case OP_CALL:
-				if strings.HasPrefix(inst.Name, "builtin.composite.") {
-					errs = append(errs, fmt.Sprintf("zerocall function %s uses composite helper call %s (unsupported)", name, inst.Name))
-					continue
+				case OP_CALL:
+					if strings.HasPrefix(inst.Name, "builtin.composite.") {
+						errs = append(errs, fmt.Sprintf("zerocall function %s uses composite helper call %s (unsupported)", name, inst.Name))
+						continue
+					}
+					if !irmod.ZeroCallFuncs[inst.Name] {
+						errs = append(errs, fmt.Sprintf("zerocall function %s calls non-zerocall function %s", name, inst.Name))
+						continue
+					}
+					edges[name] = appendUniqueString(edges[name], inst.Name)
 				}
-				if !irmod.ZeroCallFuncs[inst.Name] {
-					errs = append(errs, fmt.Sprintf("zerocall function %s calls non-zerocall function %s", name, inst.Name))
-					continue
-				}
-				if edges[name] == nil {
-					edges[name] = make(map[string]bool)
-				}
-				edges[name][inst.Name] = true
 			}
 		}
-	}
 	if len(errs) > 0 {
 		return edges, errs
 	}
@@ -190,7 +193,7 @@ func inlineZeroCallsInFunc(caller *IRFunc, funcIndex map[string]*IRFunc, zeroCal
 		}
 		for i := 0; i < frameSlots; i++ {
 			local := IRLocal{
-				Name:  fmt.Sprintf("$zerocall.%s.%d.%d", inst.Name, callSite, i),
+				Name:  "$zerocall",
 				Index: base + i,
 			}
 			if i < len(callee.Locals) {

--- a/std/compiler/ir/zerocall.go
+++ b/std/compiler/ir/zerocall.go
@@ -138,19 +138,19 @@ func validateZeroCallFuncs(irmod *IRModule, funcIndex map[string]*IRFunc) (map[s
 				errs = append(errs, fmt.Sprintf("zerocall function %s uses intrinsic call %s (unsupported)", name, inst.Name))
 			case OP_IFACE_CALL:
 				errs = append(errs, fmt.Sprintf("zerocall function %s uses interface dispatch %s (unsupported)", name, inst.Name))
-				case OP_CALL:
-					if strings.HasPrefix(inst.Name, "builtin.composite.") {
-						errs = append(errs, fmt.Sprintf("zerocall function %s uses composite helper call %s (unsupported)", name, inst.Name))
-						continue
-					}
-					if !irmod.ZeroCallFuncs[inst.Name] {
-						errs = append(errs, fmt.Sprintf("zerocall function %s calls non-zerocall function %s", name, inst.Name))
-						continue
-					}
-					edges[name] = appendUniqueString(edges[name], inst.Name)
+			case OP_CALL:
+				if strings.HasPrefix(inst.Name, "builtin.composite.") {
+					errs = append(errs, fmt.Sprintf("zerocall function %s uses composite helper call %s (unsupported)", name, inst.Name))
+					continue
 				}
+				if !irmod.ZeroCallFuncs[inst.Name] {
+					errs = append(errs, fmt.Sprintf("zerocall function %s calls non-zerocall function %s", name, inst.Name))
+					continue
+				}
+				edges[name] = appendUniqueString(edges[name], inst.Name)
 			}
 		}
+	}
 	if len(errs) > 0 {
 		return edges, errs
 	}

--- a/std/compiler/main.go
+++ b/std/compiler/main.go
@@ -693,7 +693,7 @@ func main() {
 			os.Exit(1)
 		}
 		if len(compileAsSpecs) > 0 {
-			artifacts, err := buildCompileAsArtifacts(compileTarget, baseDir, entryFiles, extraTags, compileAsSpecs)
+			artifacts, err := buildCompileAsArtifacts(&compileTarget, baseDir, entryFiles, extraTags, compileAsSpecs)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "compileas error: %v\n", err)
 				runCleanup()
@@ -843,10 +843,28 @@ func cloneStringMap(in map[string]string) map[string]string {
 	return out
 }
 
-func cloneTargetForCompileAs(base common.Target) common.Target {
-	out := base
+func cloneTargetForCompileAs(base *common.Target) common.Target {
+	var out common.Target
+	if base != nil {
+		out.Triple = base.Triple
+		out.GOOS = base.GOOS
+		out.GOARCH = base.GOARCH
+		out.PtrSize = base.PtrSize
+		out.Backend = base.Backend
+		out.CModel = base.CModel
+		out.WordSize = base.WordSize
+		out.Defines = cloneStringMap(base.Defines)
+		out.Strict = base.Strict
+		out.CompilerDebug = base.CompilerDebug
+		out.EmitIRAndBinaryPath = base.EmitIRAndBinaryPath
+		out.StripBinary = base.StripBinary
+		if len(base.StdlibIncludePaths) > 0 {
+			out.StdlibIncludePaths = append([]string{}, base.StdlibIncludePaths...)
+		}
+		out.StdlibIncludeExplicit = base.StdlibIncludeExplicit
+		out.StdlibIncludeEmbedded = base.StdlibIncludeEmbedded
+	}
 	out.BuildTags = nil
-	out.Defines = cloneStringMap(base.Defines)
 	out.Profile = false
 	out.TestMode = false
 	out.CompileAsArtifacts = nil
@@ -1019,7 +1037,21 @@ func summarizeErrors(errs []string) string {
 	return out
 }
 
-func buildCompileAsArtifacts(baseTarget common.Target, baseDir string, entryFiles []string, extraTags string, specs []frontend.CompileAsSpec) (map[string]string, error) {
+func readCompileAsArtifact(path string) ([]byte, error) {
+	payload, err := os.ReadFile(path)
+	if err == nil {
+		return payload, nil
+	}
+	// Some selfhosted outputs can land with an unreadable initial mode until chmod.
+	_ = os.Chmod(path, 0600)
+	payload, err2 := os.ReadFile(path)
+	if err2 == nil {
+		return payload, nil
+	}
+	return nil, err
+}
+
+func buildCompileAsArtifacts(baseTarget *common.Target, baseDir string, entryFiles []string, extraTags string, specs []frontend.CompileAsSpec) (map[string]string, error) {
 	if len(specs) == 0 {
 		return nil, nil
 	}
@@ -1055,12 +1087,11 @@ func buildCompileAsArtifacts(baseTarget common.Target, baseDir string, entryFile
 			return nil, fmt.Errorf("id=%s target=%s compile failed: %s", spec.ID, spec.Target, summarizeErrors(compileErrs))
 		}
 		ir.EliminateDeadFunctions(innerIR, common.EntryFuncName(&innerTarget))
-
 		outPath := fmt.Sprintf("%s/%03d_%s%s", tmpDir, i, sanitizeCompileAsName(spec.ID), compileAsOutputExt(&innerTarget))
 		if err := backend.Generate(&innerTarget, innerIR, outPath); err != nil {
 			return nil, fmt.Errorf("id=%s target=%s codegen failed: %v", spec.ID, spec.Target, err)
 		}
-		payload, err := os.ReadFile(outPath)
+		payload, err := readCompileAsArtifact(outPath)
 		if err != nil {
 			return nil, fmt.Errorf("id=%s target=%s read artifact: %v", spec.ID, spec.Target, err)
 		}

--- a/web/bundle.js
+++ b/web/bundle.js
@@ -7,6 +7,7 @@ const path = require("path");
 
 const webDir = __dirname;
 const rootDir = path.dirname(webDir);
+const exampleManifest = require(path.join(webDir, "examples-manifest.js"));
 
 // --- Step 1: Bundle std library ---
 function walkGo(dir, base) {
@@ -23,13 +24,43 @@ function walkGo(dir, base) {
 }
 
 const lib = walkGo(path.join(rootDir, "std"), "std");
+const xlib = walkGo(path.join(rootDir, "x"), "x");
 const stdLibJS = "const STD_LIBRARY = " + JSON.stringify(lib) + ";";
+const xLibJS = "const X_LIBRARY = " + JSON.stringify(xlib) + ";";
 console.log("Bundled " + Object.keys(lib).length + " std library files");
+console.log("Bundled " + Object.keys(xlib).length + " x library files");
+
+function buildExampleLibrary() {
+  return exampleManifest.map((spec) => {
+    const files = {};
+    for (const mapping of spec.files || []) {
+      files[mapping.to] = fs.readFileSync(path.join(rootDir, mapping.from), "utf8");
+    }
+    return {
+      defaultTarget: spec.defaultTarget || "wasi/wasm32",
+      smoke: spec.smoke !== false,
+      openPath: spec.openPath || Object.keys(files)[0] || "user/main.go",
+      files,
+    };
+  });
+}
+
+const examples = buildExampleLibrary();
+const examplesLibJS = "const EXAMPLE_LIBRARY = " + JSON.stringify(examples) + ";";
+console.log("Bundled " + examples.length + " examples");
 
 // Also write the ES module version for dev mode
 fs.writeFileSync(
   path.join(webDir, "std-library.js"),
   "// Auto-generated - do not edit\nexport const STD_LIBRARY = " + JSON.stringify(lib) + ";\n"
+);
+fs.writeFileSync(
+  path.join(webDir, "x-library.js"),
+  "// Auto-generated - do not edit\nexport const X_LIBRARY = " + JSON.stringify(xlib) + ";\n"
+);
+fs.writeFileSync(
+  path.join(webDir, "examples-library.js"),
+  "// Auto-generated - do not edit\nexport const EXAMPLE_LIBRARY = " + JSON.stringify(examples) + ";\n"
 );
 
 // --- Step 2: Read source files ---
@@ -59,6 +90,12 @@ const script = [
   "",
   "// --- std-library.js ---",
   stdLibJS,
+  "",
+  "// --- x-library.js ---",
+  xLibJS,
+  "",
+  "// --- examples-library.js ---",
+  examplesLibJS,
   "",
   "// --- playground.js ---",
   stripImports(playgroundJS),

--- a/web/bundle.js
+++ b/web/bundle.js
@@ -111,7 +111,7 @@ html = html.replace(
 
 // Patch loadCompilerModule to decode from base64 instead of fetching
 html = html.replace(
-  'compilerModule = await WebAssembly.compileStreaming(fetch("compiler.wasm"));',
+  "compilerModule = await WebAssembly.compileStreaming(response);",
   [
     "const b64 = COMPILER_WASM_B64;",
     "    const binStr = atob(b64);",

--- a/web/examples-manifest.js
+++ b/web/examples-manifest.js
@@ -1,0 +1,146 @@
+module.exports = [
+  {
+    id: "go-hello",
+    category: "Go",
+    title: "Hello",
+    description: "A tiny starting point for printing to stdout.",
+    defaultTarget: "wasi/wasm32",
+    openPath: "examples/go/hello/main.go",
+    files: [
+      { from: "web/examples-src/go/hello/main.go", to: "examples/go/hello/main.go" },
+    ],
+  },
+  {
+    id: "go-control-flow",
+    category: "Go",
+    title: "Control Flow",
+    description: "Basic functions, switch statements, and loops.",
+    defaultTarget: "wasi/wasm32",
+    openPath: "examples/go/control_flow/main.go",
+    files: [
+      { from: "web/examples-src/go/control_flow/main.go", to: "examples/go/control_flow/main.go" },
+    ],
+  },
+  {
+    id: "go-collections",
+    category: "Go",
+    title: "Collections",
+    description: "Slices, maps, and range loops.",
+    defaultTarget: "wasi/wasm32",
+    openPath: "examples/go/collections/main.go",
+    files: [
+      { from: "web/examples-src/go/collections/main.go", to: "examples/go/collections/main.go" },
+    ],
+  },
+  {
+    id: "go-multifile",
+    category: "Go",
+    title: "Multi-File Package",
+    description: "A simple package spread across multiple files.",
+    defaultTarget: "wasi/wasm32",
+    openPath: "examples/go/multifile/main.go",
+    files: [
+      { from: "web/examples-src/go/multifile/main.go", to: "examples/go/multifile/main.go" },
+      { from: "web/examples-src/go/multifile/helpers.go", to: "examples/go/multifile/helpers.go" },
+    ],
+  },
+  {
+    id: "compileas-artifacts",
+    category: "Directives",
+    title: "Embedded Artifacts",
+    description: "Use //rtg:compileas and //rtg:artifact to bake inner target binaries into the main program.",
+    defaultTarget: "wasi/wasm32",
+    openPath: "examples/directives/compileas_embed/main.go",
+    files: [
+      { from: "web/examples-src/directives/compileas_embed/main.go", to: "examples/directives/compileas_embed/main.go" },
+    ],
+  },
+  {
+    id: "zerocall-methods",
+    category: "Directives",
+    title: "Zero-Call Methods",
+    description: "Show //rtg:zerocall on functions and methods without losing regular Go structure.",
+    defaultTarget: "wasi/wasm32",
+    openPath: "examples/directives/zerocall_methods/main.go",
+    files: [
+      { from: "tests/zerocall_type_methods.go", to: "examples/directives/zerocall_methods/main.go" },
+    ],
+  },
+  {
+    id: "targetfile-darwin-arm64",
+    category: "Directives",
+    title: "Custom Targetfile",
+    description: "Declare assembler, binfmt, target, and target ABI providers directly in Go source.",
+    defaultTarget: "darwin/arm64",
+    openPath: "examples/directives/targetfile_darwin_arm64/main.go",
+    files: [
+      { from: "tests/targetfile_darwin_arm64.go", to: "examples/directives/targetfile_darwin_arm64/main.go" },
+    ],
+  },
+  {
+    id: "asm-amd64",
+    category: "Directives",
+    title: "Inline AMD64 Assembly",
+    description: "Emit native amd64 instructions with //rtg:assemble and the x/asm helpers.",
+    defaultTarget: "linux/amd64",
+    openPath: "examples/directives/asm_amd64/main.go",
+    files: [
+      { from: "tests/38_asm_param_balance_amd64.go", to: "examples/directives/asm_amd64/main.go" },
+    ],
+  },
+  {
+    id: "runtime-now",
+    category: "Runtime",
+    title: "runtime.Now()",
+    description: "Exercise RTG's monotonic clock support in a browser-runnable target.",
+    defaultTarget: "wasi/wasm32",
+    openPath: "examples/runtime/runtime_now/main.go",
+    files: [
+      { from: "tests/53_runtime_now.go", to: "examples/runtime/runtime_now/main.go" },
+    ],
+  },
+  {
+    id: "windows-console-basic",
+    category: "Windows",
+    title: "Windows Console Basics",
+    description: "Interact with the Windows console API and inspect handles, modes, and input state.",
+    defaultTarget: "windows/386",
+    openPath: "examples/windows/basic/main.go",
+    files: [
+      { from: "examples/windows/basic/main_windows.go", to: "examples/windows/basic/main.go" },
+    ],
+  },
+  {
+    id: "windows-console-colors",
+    category: "Windows",
+    title: "Windows Console Colors",
+    description: "Drive console attributes directly for colored text and buffer manipulation.",
+    defaultTarget: "windows/386",
+    openPath: "examples/windows/colors/main.go",
+    files: [
+      { from: "examples/windows/colors/main_windows.go", to: "examples/windows/colors/main.go" },
+    ],
+  },
+  {
+    id: "windows-console-input",
+    category: "Windows",
+    title: "Windows Console Input",
+    description: "Read and echo console input with the low-level Windows helpers in x/os/windows/console.",
+    defaultTarget: "windows/386",
+    openPath: "examples/windows/input/main.go",
+    files: [
+      { from: "examples/windows/input/main_windows.go", to: "examples/windows/input/main.go" },
+    ],
+  },
+  {
+    id: "windows-ui-window",
+    category: "Windows",
+    title: "WinUI Echo Window",
+    description: "Create a native window, controls, and a message loop with x/os/windows/winui.",
+    defaultTarget: "windows/386",
+    openPath: "examples/windows/window/main.go",
+    files: [
+      { from: "examples/windows/window/main_windows.go", to: "examples/windows/window/main.go" },
+    ],
+  },
+];

--- a/web/examples-src/directives/compileas_embed/main.go
+++ b/web/examples-src/directives/compileas_embed/main.go
@@ -1,0 +1,55 @@
+package main
+
+//rtg:compileas id=inner_linux_arm64 target=linux/arm64
+func innerLinuxArm64Entry() {
+}
+
+//rtg:artifact id=inner_linux_arm64
+var innerLinuxArm64 []byte
+
+//rtg:compileas id=inner_windows_386 target=windows/386
+func innerWindows386Entry() {
+}
+
+//rtg:artifact id=inner_windows_386
+var innerWindows386 []byte
+
+func hasPrefix(data []byte, prefix []byte) bool {
+	if len(data) < len(prefix) {
+		return false
+	}
+	i := 0
+	for i < len(prefix) {
+		if data[i] != prefix[i] {
+			return false
+		}
+		i++
+	}
+	return true
+}
+
+func main() {
+	passed := true
+
+	if len(innerLinuxArm64) < 4 {
+		println("FAIL: inner linux/arm64 artifact is empty")
+		passed = false
+	} else if !hasPrefix(innerLinuxArm64, []byte{0x7f, 'E', 'L', 'F'}) {
+		println("FAIL: inner linux/arm64 artifact is not ELF")
+		passed = false
+	}
+
+	if len(innerWindows386) < 2 {
+		println("FAIL: inner windows/386 artifact is empty")
+		passed = false
+	} else if !hasPrefix(innerWindows386, []byte{'M', 'Z'}) {
+		println("FAIL: inner windows/386 artifact is not PE/MZ")
+		passed = false
+	}
+
+	if passed {
+		println("PASS")
+	} else {
+		panic("artifact validation failed")
+	}
+}

--- a/web/examples-src/go/collections/main.go
+++ b/web/examples-src/go/collections/main.go
@@ -1,0 +1,19 @@
+package main
+
+import "fmt"
+
+func main() {
+	numbers := []int{3, 5, 8, 13}
+	total := 0
+	for _, n := range numbers {
+		total += n
+	}
+
+	labels := map[string]int{
+		"count": len(numbers),
+		"sum":   total,
+	}
+
+	fmt.Println("numbers:", numbers)
+	fmt.Println("labels:", labels)
+}

--- a/web/examples-src/go/control_flow/main.go
+++ b/web/examples-src/go/control_flow/main.go
@@ -1,0 +1,22 @@
+package main
+
+import "fmt"
+
+func classify(n int) string {
+	switch {
+	case n%15 == 0:
+		return "fizzbuzz"
+	case n%3 == 0:
+		return "fizz"
+	case n%5 == 0:
+		return "buzz"
+	default:
+		return fmt.Sprintf("%d", n)
+	}
+}
+
+func main() {
+	for i := 1; i <= 15; i++ {
+		fmt.Println(classify(i))
+	}
+}

--- a/web/examples-src/go/hello/main.go
+++ b/web/examples-src/go/hello/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello from RTG")
+}

--- a/web/examples-src/go/multifile/helpers.go
+++ b/web/examples-src/go/multifile/helpers.go
@@ -1,0 +1,14 @@
+package main
+
+type player struct {
+	name  string
+	score int
+}
+
+func averageScore(players []player) int {
+	total := 0
+	for _, p := range players {
+		total += p.score
+	}
+	return total / len(players)
+}

--- a/web/examples-src/go/multifile/main.go
+++ b/web/examples-src/go/multifile/main.go
@@ -1,0 +1,13 @@
+package main
+
+import "fmt"
+
+func main() {
+	team := []player{
+		{name: "Ada", score: 7},
+		{name: "Ken", score: 9},
+		{name: "Rob", score: 8},
+	}
+
+	fmt.Println("average score:", averageScore(team))
+}

--- a/web/index.html
+++ b/web/index.html
@@ -38,7 +38,7 @@
       flex-direction: column;
       overflow: hidden;
     }
-    button, select { font-family: inherit; font-size: inherit; }
+    button, select, input { font-family: inherit; font-size: inherit; }
     .hidden { display: none !important; }
 
     /* ── Scrollbar ─────────────────────────────────────────── */
@@ -109,6 +109,27 @@
       align-items: center;
       gap: 6px;
     }
+    #mobile-view-toggle {
+      display: none;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 12px;
+      border-bottom: 1px solid var(--border-dim);
+      background: linear-gradient(180deg, #141d31 0%, #111827 100%);
+    }
+    .mobile-view-btn {
+      flex: 1;
+      padding: 6px 10px;
+      border: 1px solid var(--border);
+      background: var(--bg-panel);
+      color: var(--text-dim);
+      font-weight: 600;
+    }
+    .mobile-view-btn.active {
+      background: var(--bg-raised);
+      border-color: var(--accent);
+      color: var(--text-bright);
+    }
     #target-select {
       background: var(--bg-raised);
       color: var(--text);
@@ -167,6 +188,20 @@
       box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
       z-index: 120;
     }
+    #targets-panel {
+      position: fixed;
+      top: 42px;
+      right: 12px;
+      width: 360px;
+      max-height: 70vh;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      background: var(--bg-panel);
+      border: 1px solid var(--border);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+      z-index: 121;
+    }
     .tags-header {
       display: flex;
       align-items: center;
@@ -210,6 +245,13 @@
       font-family: var(--font-mono);
       font-size: 11px;
     }
+    #targets-list {
+      overflow-y: auto;
+      padding: 8px 10px;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
     .tag-row {
       display: flex;
       align-items: center;
@@ -222,6 +264,29 @@
     .tags-empty {
       color: var(--text-muted);
       font-family: var(--font-ui);
+    }
+    .panel-meta {
+      font-size: 10px;
+      color: var(--text-muted);
+    }
+    .target-option {
+      width: 100%;
+      text-align: left;
+      padding: 7px 9px;
+      border: 1px solid var(--border-dim);
+      background: var(--bg-surface);
+      color: var(--text);
+      font-family: var(--font-mono);
+      font-size: 11px;
+    }
+    .target-option:hover {
+      border-color: var(--accent);
+      background: var(--bg-raised);
+    }
+    .target-option.active {
+      border-color: var(--accent);
+      color: var(--text-bright);
+      background: linear-gradient(180deg, rgba(53, 116, 240, 0.24) 0%, rgba(30, 40, 64, 0.95) 100%);
     }
 
     /* ── Panel Layout ──────────────────────────────────────── */
@@ -639,7 +704,7 @@
     #statusbar {
       display: flex;
       align-items: center;
-      justify-content: space-between;
+      gap: 10px;
       padding: 0 12px;
       height: 22px;
       background: linear-gradient(180deg, #141c2e 0%, #101828 100%);
@@ -651,6 +716,13 @@
     .status-right {
       font-family: var(--font-mono);
       font-size: 10px;
+    }
+    #entry-path {
+      margin-left: auto;
+      max-width: 48%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
 
     /* ── Welcome Page ──────────────────────────────────────── */
@@ -800,7 +872,34 @@
     /* ── Mobile ────────────────────────────────────────────── */
     @media (max-width: 768px) {
       #btn-toggle-files { display: block; }
+      #toolbar {
+        height: auto;
+        align-items: flex-start;
+        padding: 8px 12px;
+      }
+      .toolbar-left {
+        width: 100%;
+        justify-content: space-between;
+      }
+      #toolbar-buttons {
+        width: 100%;
+      }
+      .toolbar-group {
+        width: 100%;
+        flex-wrap: wrap;
+      }
+      #target-select {
+        flex: 1 1 180px;
+      }
+      #mobile-view-toggle { display: flex; }
       #main-panels { flex-direction: column; }
+      #main-panels.mobile-view-editor #panel-output { display: none; }
+      #main-panels.mobile-view-output #panel-editor { display: none; }
+      #main-panels.mobile-view-output #panel-output {
+        display: flex;
+        max-height: none;
+        flex: 1;
+      }
       .panel-resize-handle { display: none; }
 
       #panel-files {
@@ -840,22 +939,48 @@
         grid-template-columns: 1fr;
         gap: 20px;
       }
-
       #toolbar h1 { font-size: 13px; }
       .btn { padding: 4px 8px; font-size: 11px; }
       #target-select { font-size: 11px; padding: 3px 4px; }
       #tags-panel {
-        top: 40px;
+        top: 82px;
         right: 8px;
         width: calc(100vw - 16px);
         max-height: 50vh;
       }
+      #targets-panel {
+        top: 82px;
+        right: 8px;
+        width: calc(100vw - 16px);
+        max-height: calc(100vh - 140px);
+      }
+      #entry-path {
+        max-width: 38%;
+      }
     }
 
     @media (max-width: 480px) {
+      #toolbar {
+        gap: 10px;
+      }
+      #toolbar-buttons {
+        gap: 8px;
+      }
+      .toolbar-group {
+        gap: 8px;
+      }
       .download-links { flex-direction: column; }
       .download-link { text-align: center; }
       .target-grid { grid-template-columns: 1fr 1fr; }
+      #statusbar {
+        padding: 0 8px;
+      }
+      #compiler-stamp {
+        display: none;
+      }
+      #entry-path {
+        max-width: 58%;
+      }
     }
   </style>
 </head>
@@ -868,7 +993,7 @@
     </div>
     <div id="toolbar-buttons">
       <div class="toolbar-group">
-        <select id="target-select">
+        <select id="target-select" class="hidden">
           <option value="wasi/wasm32">wasi/wasm32</option>
           <option value="linux/amd64">linux/amd64</option>
           <option value="linux/386">linux/386</option>
@@ -882,6 +1007,7 @@
           <option value="c/16">c/16</option>
           <option value="dos/8086">dos/8086</option>
         </select>
+        <button id="btn-targets" class="btn btn-gray">wasi/wasm32</button>
         <button id="btn-emit-ir" class="btn btn-gray" aria-pressed="false" title="Emit textual IR for the selected target">Emit IR</button>
         <button id="btn-tags" class="btn btn-gray">Build Tags</button>
       </div>
@@ -889,6 +1015,10 @@
       <button id="btn-run" class="btn btn-green" disabled>Run</button>
       <button id="btn-download" class="btn btn-gray hidden" disabled>Download</button>
     </div>
+  </div>
+  <div id="mobile-view-toggle">
+    <button id="btn-mobile-editor" class="mobile-view-btn active">Editor</button>
+    <button id="btn-mobile-output" class="mobile-view-btn">Output</button>
   </div>
   <div id="tags-panel" class="hidden">
     <div class="tags-header">
@@ -901,6 +1031,15 @@
       </div>
     </div>
     <div id="tags-list"></div>
+  </div>
+  <div id="targets-panel" class="hidden">
+    <div class="tags-header">
+      <div class="tags-header-left">
+        <span class="tags-title">Targets</span>
+        <span id="targets-meta" class="panel-meta">Choose a compile target</span>
+      </div>
+    </div>
+    <div id="targets-list"></div>
   </div>
 
   <!-- Main panels -->
@@ -1043,6 +1182,7 @@
 
   <div id="statusbar">
     <span id="status">Ready</span>
+    <span id="entry-path" class="status-right">Entry user/</span>
     <span id="compiler-stamp" class="status-right">RTG Compiler</span>
   </div>
 

--- a/web/node-compile-examples-smoke.mjs
+++ b/web/node-compile-examples-smoke.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+function fail(message) {
+  console.error(`error: ${message}`);
+  process.exit(1);
+}
+
+function loadExportedJSON(relPath, exportName) {
+  const fullPath = path.join(repoRoot, relPath);
+  const src = fs.readFileSync(fullPath, "utf8");
+  const marker = `export const ${exportName} = `;
+  const start = src.indexOf(marker);
+  if (start < 0) fail(`${relPath} does not contain ${exportName} export`);
+  const jsonStart = start + marker.length;
+  const jsonEnd = src.lastIndexOf(";");
+  if (jsonEnd <= jsonStart) fail(`failed to parse ${exportName} payload from ${relPath}`);
+  try {
+    return JSON.parse(src.slice(jsonStart, jsonEnd));
+  } catch (err) {
+    fail(`failed to parse ${exportName} from ${relPath}: ${err.message}`);
+  }
+}
+
+function asText(chunks) {
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function runWasiModule(module, fsView, args, hooks) {
+  const stdout = [];
+  const stderr = [];
+  const { createWASI, WASIExit } = hooks;
+
+  const wasi = createWASI(fsView, args, {
+    onStdout: (data) => stdout.push(Buffer.from(data)),
+    onStderr: (data) => stderr.push(Buffer.from(data)),
+  });
+
+  const instance = await WebAssembly.instantiate(module, wasi.imports);
+  wasi.setMemory(instance.exports.memory);
+
+  let exitCode = 0;
+  try {
+    instance.exports._start();
+  } catch (err) {
+    if (err instanceof WASIExit) {
+      exitCode = err.code;
+    } else {
+      throw err;
+    }
+  }
+
+  return {
+    exitCode,
+    stdout: asText(stdout),
+    stderr: asText(stderr),
+  };
+}
+
+function addLibrary(fsView, lib) {
+  for (const [filePath, content] of Object.entries(lib)) {
+    fsView.addFile(filePath, content);
+  }
+}
+
+function packageEntry(pathname) {
+  const slash = pathname.lastIndexOf("/");
+  return slash >= 0 ? pathname.slice(0, slash) : pathname;
+}
+
+async function main() {
+  const tmpDir = path.join(repoRoot, "build", "web-wasm-selfhost-node");
+  fs.mkdirSync(tmpDir, { recursive: true });
+  const wasiModulePath = path.join(tmpDir, "wasi.mjs");
+  fs.copyFileSync(path.join(repoRoot, "web", "wasi.js"), wasiModulePath);
+
+  const wasiModule = await import(pathToFileURL(wasiModulePath).href);
+  const { VirtualFS, createWASI, WASIExit } = wasiModule;
+  if (!VirtualFS || !createWASI || !WASIExit) {
+    fail("failed to load WASI helpers from web/wasi.js");
+  }
+
+  const stdLibrary = loadExportedJSON("web/std-library.js", "STD_LIBRARY");
+  const xLibrary = loadExportedJSON("web/x-library.js", "X_LIBRARY");
+  const examples = loadExportedJSON("web/examples-library.js", "EXAMPLE_LIBRARY");
+
+  const compilerWasmPath = path.join(repoRoot, "web", "compiler.wasm");
+  const compilerWasm = fs.readFileSync(compilerWasmPath);
+  const compilerModule = await WebAssembly.compile(compilerWasm);
+
+  const fsStage1 = new VirtualFS();
+  addLibrary(fsStage1, stdLibrary);
+  addLibrary(fsStage1, xLibrary);
+  const stage1Out = "build/examples_stage1_compiler.wasm";
+  const stage1 = await runWasiModule(
+    compilerModule,
+    fsStage1,
+    ["rtg", "-T", "wasi/wasm32", "-o", stage1Out, "std/compiler"],
+    { createWASI, WASIExit }
+  );
+  if (stage1.exitCode !== 0) {
+    fail(`webpage WASM compiler self-compile failed with ${stage1.exitCode}\n${(stage1.stdout + stage1.stderr).trim()}`);
+  }
+  const stage1Bytes = fsStage1.readFile(stage1Out);
+  if (!stage1Bytes || stage1Bytes.length === 0) {
+    fail(`self-compiled compiler did not produce ${stage1Out}`);
+  }
+  const generatedCompilerModule = await WebAssembly.compile(stage1Bytes);
+  let compiledCount = 0;
+  let skippedCount = 0;
+  const failures = [];
+
+  for (let i = 0; i < examples.length; i++) {
+    const example = examples[i];
+    if (example.smoke === false) {
+      skippedCount++;
+      continue;
+    }
+    const entryPath = packageEntry(example.openPath);
+    const fsView = new VirtualFS();
+    addLibrary(fsView, stdLibrary);
+    addLibrary(fsView, xLibrary);
+    addLibrary(fsView, example.files || {});
+
+    const outputPath = `build/example_${i}.out`;
+    let compile;
+    try {
+      compile = await runWasiModule(
+        generatedCompilerModule,
+        fsView,
+        ["rtg", "-T", example.defaultTarget || "wasi/wasm32", "-o", outputPath, entryPath],
+        { createWASI, WASIExit }
+      );
+    } catch (err) {
+      failures.push(
+        `example ${entryPath} (${example.defaultTarget}) trapped\n${err && err.stack ? err.stack : String(err)}`
+      );
+      continue;
+    }
+    if (compile.exitCode !== 0) {
+      failures.push(
+        `example ${entryPath} (${example.defaultTarget}) failed with ${compile.exitCode}\n${(compile.stdout + compile.stderr).trim()}`
+      );
+      continue;
+    }
+    const out = fsView.readFile(outputPath);
+    if (!out || out.length === 0) {
+      failures.push(`example ${entryPath} (${example.defaultTarget}) produced no output`);
+      continue;
+    }
+    compiledCount++;
+  }
+
+  if (failures.length > 0) {
+    fail(failures.join("\n\n"));
+  }
+
+  console.log(
+    `PASS: webpage WASM compiler compiled ${compiledCount} bundled examples` +
+      (skippedCount > 0 ? ` (skipped ${skippedCount} known-broken example)` : "")
+  );
+}
+
+main().catch((err) => {
+  fail(err && err.stack ? err.stack : String(err));
+});

--- a/web/playground.js
+++ b/web/playground.js
@@ -1,11 +1,35 @@
 import { VirtualFS, createWASI, WASIExit } from "./wasi.js";
 import { STD_LIBRARY } from "./std-library.js";
+import { X_LIBRARY } from "./x-library.js";
+import { EXAMPLE_LIBRARY } from "./examples-library.js";
+
+const DEFAULT_USER_FILES = {
+  "user/main.go": `package main
+
+import "fmt"
+
+func main() {
+\tfmt.Println("Hello from RTG2!")
+}
+`,
+};
+
+const EXAMPLE_FILES = {};
+const EXAMPLE_BY_PATH = new Map();
+for (const example of EXAMPLE_LIBRARY) {
+  for (const [path, content] of Object.entries(example.files || {})) {
+    EXAMPLE_FILES[path] = content;
+    EXAMPLE_BY_PATH.set(path, example);
+  }
+  if (example.openPath) EXAMPLE_BY_PATH.set(example.openPath, example);
+}
 
 // --- State ---
 let userFiles = {};       // { path: content }
 let activeFile = null;    // currently open file path
 let compiledWasm = null;  // Uint8Array of compiled output
 let compiledTarget = null; // target the last compile was for
+let compiledEntry = null; // package path used for the last compile
 let compilerModule = null; // cached WebAssembly.Module for the compiler
 let saveTimer = null;
 let dirty = true;         // files changed since last compile
@@ -28,6 +52,7 @@ const btnDownload = document.getElementById("btn-download");
 const btnNewFile = document.getElementById("btn-new-file");
 const btnClearOutput = document.getElementById("btn-clear-output");
 const targetSelect = document.getElementById("target-select");
+const btnTargets = document.getElementById("btn-targets");
 const btnEmitIR = document.getElementById("btn-emit-ir");
 const panelOutput = document.getElementById("panel-output");
 const irViewer = document.getElementById("ir-viewer");
@@ -39,19 +64,32 @@ const tagsPanel = document.getElementById("tags-panel");
 const tagsList = document.getElementById("tags-list");
 const tagsMeta = document.getElementById("tags-meta");
 const btnRescanTags = document.getElementById("btn-rescan-tags");
+const targetsPanel = document.getElementById("targets-panel");
+const targetsList = document.getElementById("targets-list");
+const targetsMeta = document.getElementById("targets-meta");
+const btnMobileEditor = document.getElementById("btn-mobile-editor");
+const btnMobileOutput = document.getElementById("btn-mobile-output");
+const mainPanels = document.getElementById("main-panels");
+const entryPathEl = document.getElementById("entry-path");
 const compilerStampEl = document.getElementById("compiler-stamp");
 
 // --- Init ---
 function init() {
+  targetSelect.value = "wasi/wasm32";
   loadUserFiles();
   renderFileTree();
   openFile("user/main.go");
   setupEditorEvents();
   setupButtons();
   setupTagPanel();
+  setupTargetPanel();
+  setupMobilePanels();
   renderBuildTags();
+  renderTargetPanel();
   loadCompilerModule();
   updateDirtyIndicator();
+  updateEntryIndicator();
+  updateTargetButton();
   discoverBuildTags();
 }
 
@@ -64,17 +102,7 @@ function loadUserFiles() {
       return;
     }
   } catch {}
-  // Default
-  userFiles = {
-    "user/main.go": `package main
-
-import "fmt"
-
-func main() {
-\tfmt.Println("Hello from RTG2!")
-}
-`,
-  };
+  userFiles = cloneFileMap(DEFAULT_USER_FILES);
   saveUserFiles();
 }
 
@@ -98,6 +126,10 @@ function saveEnabledBuildTags() {
   localStorage.setItem("rtg2-build-tags", JSON.stringify(Array.from(enabledBuildTags).sort()));
 }
 
+function cloneFileMap(files) {
+  return Object.fromEntries(Object.entries(files).map(([path, content]) => [path, content]));
+}
+
 // --- Dirty tracking ---
 function markDirty() {
   dirty = true;
@@ -113,20 +145,106 @@ function updateDirtyIndicator() {
   editorDirty.classList.toggle("hidden", !dirty);
 }
 
+function isMobileViewport() {
+  return window.innerWidth <= 768;
+}
+
+function setMobilePanel(panel) {
+  if (!mainPanels) return;
+  if (!isMobileViewport()) {
+    mainPanels.classList.remove("mobile-view-editor", "mobile-view-output");
+    btnMobileEditor.classList.remove("active");
+    btnMobileOutput.classList.remove("active");
+    return;
+  }
+  mainPanels.classList.toggle("mobile-view-editor", panel === "editor");
+  mainPanels.classList.toggle("mobile-view-output", panel === "output");
+  btnMobileEditor.classList.toggle("active", panel === "editor");
+  btnMobileOutput.classList.toggle("active", panel === "output");
+}
+
+function setupMobilePanels() {
+  btnMobileEditor.addEventListener("click", () => setMobilePanel("editor"));
+  btnMobileOutput.addEventListener("click", () => setMobilePanel("output"));
+  window.addEventListener("resize", () => {
+    setMobilePanel(mainPanels.classList.contains("mobile-view-output") ? "output" : "editor");
+  });
+  setMobilePanel("editor");
+}
+
+function dirname(path) {
+  const slash = path.lastIndexOf("/");
+  return slash >= 0 ? path.slice(0, slash) : path;
+}
+
+function getCompileEntryPath() {
+  if (!activeFile) return "user";
+  return dirname(activeFile);
+}
+
+function updateEntryIndicator() {
+  const entryPath = getCompileEntryPath();
+  if (entryPathEl) entryPathEl.textContent = "Entry " + entryPath;
+  btnCompile.title = "Compile active package: " + entryPath;
+}
+
+function updateTargetButton() {
+  btnTargets.textContent = targetSelect.value;
+  if (targetsMeta) targetsMeta.textContent = targetSelect.value;
+}
+
+function handleTargetChange() {
+  updateTargetButton();
+  renderTargetPanel();
+  updateRunVisibility();
+  markDirty();
+  resetCompiledOutputState();
+  discoverBuildTags();
+}
+
+function setTargetValue(target) {
+  if (!target || targetSelect.value === target) {
+    updateTargetButton();
+    return false;
+  }
+  targetSelect.value = target;
+  handleTargetChange();
+  return true;
+}
+
+function resetCompiledOutputState() {
+  compiledWasm = null;
+  compiledTarget = null;
+  compiledEntry = null;
+  btnRun.disabled = true;
+  btnDownload.disabled = true;
+  btnDownload.classList.add("hidden");
+  showIRViewer(false);
+  document.getElementById("size-analysis").classList.add("hidden");
+}
+
 // --- File Tree ---
 function renderFileTree() {
   fileTree.innerHTML = "";
 
   // User files section
-  const userSection = buildTreeSection("user", userFiles, false);
+  const userSection = buildTreeSection("user", userFiles, false, true);
   fileTree.appendChild(userSection);
 
+  // Examples section
+  const examplesSection = buildTreeSection("examples", EXAMPLE_FILES, true, true);
+  fileTree.appendChild(examplesSection);
+
   // Std library section
-  const stdSection = buildTreeSection("std", STD_LIBRARY, true);
+  const stdSection = buildTreeSection("std", STD_LIBRARY, true, false);
   fileTree.appendChild(stdSection);
+
+  // x library section
+  const xSection = buildTreeSection("x", X_LIBRARY, true, false);
+  fileTree.appendChild(xSection);
 }
 
-function buildTreeSection(rootName, filesObj, readOnly) {
+function buildTreeSection(rootName, filesObj, readOnly, startOpen) {
   const tree = {};
   for (const path of Object.keys(filesObj)) {
     const parts = path.split("/");
@@ -144,7 +262,7 @@ function buildTreeSection(rootName, filesObj, readOnly) {
 
   const rootNode = tree[rootName];
   if (!rootNode) return document.createDocumentFragment();
-  return renderTreeNode(rootName, rootNode, rootName, readOnly, !readOnly);
+  return renderTreeNode(rootName, rootNode, rootName, readOnly, startOpen);
 }
 
 function renderTreeNode(name, children, fullPath, readOnly, startOpen) {
@@ -197,9 +315,11 @@ function renderTreeNode(name, children, fullPath, readOnly, startOpen) {
 // --- Editor ---
 function openFile(path) {
   saveCurrentFile();
+  const previousEntry = getCompileEntryPath();
 
   activeFile = path;
   editorFilename.textContent = path;
+  const example = EXAMPLE_BY_PATH.get(path) || null;
 
   const isUserFile = path.startsWith("user/");
 
@@ -209,7 +329,7 @@ function openFile(path) {
     editorReadonlyBadge.classList.add("hidden");
     btnDeleteFile.classList.toggle("hidden", path === "user/main.go");
   } else {
-    editor.value = STD_LIBRARY[path] || "";
+    editor.value = EXAMPLE_FILES[path] || STD_LIBRARY[path] || X_LIBRARY[path] || "";
     editor.readOnly = true;
     editorReadonlyBadge.classList.remove("hidden");
     btnDeleteFile.classList.add("hidden");
@@ -218,6 +338,15 @@ function openFile(path) {
   for (const el of fileTree.querySelectorAll(".tree-item")) {
     el.classList.toggle("active", el.dataset.path === path);
   }
+  if (compiledEntry !== null && getCompileEntryPath() !== previousEntry) {
+    resetCompiledOutputState();
+    markDirty();
+  }
+  if (example && example.defaultTarget) {
+    setTargetValue(example.defaultTarget);
+  }
+  updateEntryIndicator();
+  setMobilePanel("editor");
 }
 
 function saveCurrentFile() {
@@ -264,23 +393,12 @@ function setupButtons() {
     updateEmitIRButton();
     updateRunVisibility();
     markDirty();
-    compiledWasm = null;
-    btnDownload.disabled = true;
-    btnDownload.classList.add("hidden");
-    showIRViewer(false);
+    resetCompiledOutputState();
     discoverBuildTags();
   });
 
   targetSelect.addEventListener("change", () => {
-    // Target change means recompile is needed
-    updateRunVisibility();
-    markDirty();
-    compiledWasm = null;
-    btnRun.disabled = true;
-    btnDownload.disabled = true;
-    btnDownload.classList.add("hidden");
-    showIRViewer(false);
-    discoverBuildTags();
+    handleTargetChange();
   });
 
   btnNewFile.addEventListener("click", () => {
@@ -309,12 +427,14 @@ function setupButtons() {
   });
 
   updateEmitIRButton();
+  updateTargetButton();
   updateRunVisibility();
 }
 
 function setupTagPanel() {
   btnTags.addEventListener("click", (e) => {
     e.stopPropagation();
+    targetsPanel.classList.add("hidden");
     const nowVisible = tagsPanel.classList.toggle("hidden") === false;
     if (nowVisible) discoverBuildTags();
   });
@@ -326,6 +446,36 @@ function setupTagPanel() {
   btnRescanTags.addEventListener("click", () => {
     discoverBuildTags();
   });
+}
+
+function setupTargetPanel() {
+  btnTargets.addEventListener("click", (e) => {
+    e.stopPropagation();
+    tagsPanel.classList.add("hidden");
+    targetsPanel.classList.toggle("hidden");
+  });
+  document.addEventListener("click", (e) => {
+    if (targetsPanel.classList.contains("hidden")) return;
+    if (targetsPanel.contains(e.target) || e.target === btnTargets) return;
+    targetsPanel.classList.add("hidden");
+  });
+}
+
+function renderTargetPanel() {
+  targetsList.replaceChildren();
+  for (const option of targetSelect.options) {
+    const button = document.createElement("button");
+    button.className = "target-option";
+    button.textContent = option.value;
+    button.classList.toggle("active", option.value === targetSelect.value);
+    button.addEventListener("click", () => {
+      setTargetValue(option.value);
+      renderTargetPanel();
+      targetsPanel.classList.add("hidden");
+    });
+    targetsList.appendChild(button);
+  }
+  targetsMeta.textContent = targetSelect.value;
 }
 
 function renderBuildTags() {
@@ -513,13 +663,20 @@ async function discoverBuildTags() {
     for (const [path, content] of Object.entries(STD_LIBRARY)) {
       fs.addFile(path, content);
     }
+    for (const [path, content] of Object.entries(X_LIBRARY)) {
+      fs.addFile(path, content);
+    }
+    for (const [path, content] of Object.entries(EXAMPLE_FILES)) {
+      fs.addFile(path, content);
+    }
     for (const [path, content] of Object.entries(userFiles)) {
       fs.addFile(path, content);
     }
 
+    const entryPath = getCompileEntryPath();
     const args = ["rtg", "-T", targetSelect.value, "-parse-only", "-list-build-tags", "build-tags.txt"];
     appendTagArgs(args);
-    args.push("user/");
+    args.push(entryPath);
 
     const exitCode = await runCompilerInWasi(fs, args);
     if (exitCode !== 0) {
@@ -561,12 +718,11 @@ async function compile() {
   const isIR = shouldEmitIR();
   const outputTarget = isIR ? "ir" : target;
   const outputFile = getOutputFilename(outputTarget);
+  const entryPath = getCompileEntryPath();
 
   outputContent.innerHTML = "";
-  compiledWasm = null;
-  btnRun.disabled = true;
-  btnDownload.disabled = true;
-  btnDownload.classList.add("hidden");
+  resetCompiledOutputState();
+  setMobilePanel("output");
   setStatus("Compiling...");
   btnCompile.disabled = true;
 
@@ -579,20 +735,27 @@ async function compile() {
     for (const [path, content] of Object.entries(STD_LIBRARY)) {
       fs.addFile(path, content);
     }
+    for (const [path, content] of Object.entries(X_LIBRARY)) {
+      fs.addFile(path, content);
+    }
+
+    // Add bundled examples
+    for (const [path, content] of Object.entries(EXAMPLE_FILES)) {
+      fs.addFile(path, content);
+    }
 
     // Add all user files
     for (const [path, content] of Object.entries(userFiles)) {
       fs.addFile(path, content);
     }
 
-    const entryFile = "user/main.go";
     const args = ["rtg", "-T", target];
     appendTagArgs(args);
     if (isIR) {
-      args.push("-emit-ir", outputFile, entryFile);
+      args.push("-emit-ir", outputFile, entryPath);
     } else {
       args.push("-size-analysis", "size-analysis.json");
-      args.push("-o", outputFile, entryFile);
+      args.push("-o", outputFile, entryPath);
     }
 
     const exitCode = await runCompilerInWasi(fs, args, {
@@ -612,11 +775,12 @@ async function compile() {
     if (output && output.length > 0) {
       compiledWasm = output;
       compiledTarget = outputTarget;
+      compiledEntry = entryPath;
       markClean();
 
       if (isIR) {
         const irText = new TextDecoder().decode(output);
-        appendOutput(`IR generated (${irText.split("\n").length} lines) in ${elapsed}s\n`, "stdout");
+        appendOutput(`IR generated for ${entryPath} (${irText.split("\n").length} lines) in ${elapsed}s\n`, "stdout");
         renderIRViewer(irText);
         showIRViewer(true);
         btnRun.disabled = true;
@@ -630,7 +794,7 @@ async function compile() {
         btnDownload.disabled = false;
         btnDownload.classList.remove("hidden");
 
-        appendOutput(`Compiled ${output.length} bytes in ${elapsed}s\n`, "stdout");
+        appendOutput(`Compiled ${entryPath} to ${output.length} bytes in ${elapsed}s\n`, "stdout");
 
         // Read and display size analysis
         try {
@@ -662,11 +826,12 @@ async function compile() {
 // --- Run ---
 async function run() {
   // Auto-compile if dirty
-  if (dirty || !compiledWasm || compiledTarget !== "wasi/wasm32") {
+  if (dirty || !compiledWasm || compiledTarget !== "wasi/wasm32" || compiledEntry !== getCompileEntryPath()) {
     await compile();
     if (!compiledWasm || compiledTarget !== "wasi/wasm32") return;
   }
 
+  setMobilePanel("output");
   setStatus("Running...");
   btnRun.disabled = true;
 
@@ -1019,6 +1184,7 @@ window.selfCompileAndDownload = async function(target) {
   const downloadName = "rtg-" + os + "-" + arch + (isWindows ? ".exe" : "");
 
   outputContent.innerHTML = "";
+  setMobilePanel("output");
   setStatus("Building RTG for " + target + "...");
   btnCompile.disabled = true;
 

--- a/web/playground.js
+++ b/web/playground.js
@@ -594,7 +594,7 @@ async function loadCompilerModule() {
       setStatus("Failed to load compiler.wasm");
       return;
     }
-    compilerModule = await WebAssembly.compileStreaming(fetch("compiler.wasm"));
+    compilerModule = await WebAssembly.compileStreaming(response);
     setStatus("Ready");
     await loadCompilerStamp();
     discoverBuildTags();


### PR DESCRIPTION
## Summary
- improve the offline web playground with an examples tree, simpler bundled Go starter examples, active-package compilation, and mobile-targeted UI refinements
- add a Node-based webpage WASM smoke that self-compiles the browser compiler and compiles every bundled example in CI
- fix webpage-compiler failures in zerocall inlining and cross-target `//rtg:compileas` so all bundled examples compile under the Node/WASM path again

## Validation
- `bash web/build.sh`
- `node web/node-compile-examples-smoke.mjs`
- `node web/node-wasm-selfhost-smoke.mjs --platform local`
- `./build/build selfhost-wasm`
