### PR TITLE
Add float32 IR support and scalar float lowering for the C backend

### DIFF
--- a/COMPILER_BUGS.md
+++ b/COMPILER_BUGS.md
@@ -25,6 +25,7 @@ Compiler bugs/limitations discovered while implementing stdlib extensions (`erro
 - `#32` x64 Windows backend is missing lowering for runtime syscall intrinsics such as `SysRead`/`SysWrite`/`SysOpen`/`SysClose` (`ICE: unknown intrinsic 'SysRead' on GOOS=windows` when compiling stdlib-using Windows targets).
 - `#35` Struct values are lowered with pointer-aliasing semantics instead of copy semantics in RTG-compiled programs.
 - `#40` WASM variadic/interface boxing still truncates `int64` values in `fmt.Printf`-style calls.
+- `#41` C backend float lowering currently requires the C word size to be at least as wide as the float payload (`c/64` for `float64`; `c/32+` for `float32`).
 
 ### Watch (not currently reproducible)
 - `#1` ICE in `compileGlobalInits` for package-scope initializers.
@@ -68,6 +69,21 @@ Compiler bugs/limitations discovered while implementing stdlib extensions (`erro
 13. `#31` Make wasm stackification tolerate outlined panic-unwind slow paths (or preserve the inline form there).
 14. `#35` Fix struct-value copy semantics in RTG-compiled programs (current lowering aliases heap-backed struct objects).
 15. `#40` Fix wasm boxing/variadic argument handling for `int64` values.
+16. `#41` Decide whether smaller-word C profiles should gain split-word float lowering or keep an explicit unsupported-target error.
+
+### 41) C backend float lowering currently depends on word-size >= float-size
+
+**Symptom**
+- The C backend now lowers scalar `float32`/`float64` values by carrying raw IEEE bits in `rtg_word`.
+- That works for `c/64` with both `float32` and `float64`, and for `c/32` only for `float32`.
+- `c/32` cannot faithfully carry `float64`, and `c/16` cannot faithfully carry either float width, without changing the current one-word operand/local model.
+
+**Impact**
+- `float64` programs targeting `-T c/32` still need to fail early instead of silently truncating values.
+- `float32`/`float64` support on the C backend is currently a `c/64` feature in practice, with only partial reach to narrower C profiles.
+
+**Current mitigation**
+- The backend now rejects unsupported profile/float-width combinations up front instead of generating truncated code.
 
 ### 40) WASM variadic/interface boxing truncates `int64` values in formatted calls
 

--- a/std/compiler/backend/aarch64/aarch64.go
+++ b/std/compiler/backend/aarch64/aarch64.go
@@ -36,6 +36,75 @@ const (
 	REG_XZR = 31 // zero register (context-dependent)
 )
 
+// Floating-point register constants (S0-S31 / D0-D31 share the same indices).
+const (
+	REG_S0  = 0
+	REG_S1  = 1
+	REG_S2  = 2
+	REG_S3  = 3
+	REG_S4  = 4
+	REG_S5  = 5
+	REG_S6  = 6
+	REG_S7  = 7
+	REG_S8  = 8
+	REG_S9  = 9
+	REG_S10 = 10
+	REG_S11 = 11
+	REG_S12 = 12
+	REG_S13 = 13
+	REG_S14 = 14
+	REG_S15 = 15
+	REG_S16 = 16
+	REG_S17 = 17
+	REG_S18 = 18
+	REG_S19 = 19
+	REG_S20 = 20
+	REG_S21 = 21
+	REG_S22 = 22
+	REG_S23 = 23
+	REG_S24 = 24
+	REG_S25 = 25
+	REG_S26 = 26
+	REG_S27 = 27
+	REG_S28 = 28
+	REG_S29 = 29
+	REG_S30 = 30
+	REG_S31 = 31
+
+	REG_D0  = 0
+	REG_D1  = 1
+	REG_D2  = 2
+	REG_D3  = 3
+	REG_D4  = 4
+	REG_D5  = 5
+	REG_D6  = 6
+	REG_D7  = 7
+	REG_D8  = 8
+	REG_D9  = 9
+	REG_D10 = 10
+	REG_D11 = 11
+	REG_D12 = 12
+	REG_D13 = 13
+	REG_D14 = 14
+	REG_D15 = 15
+	REG_D16 = 16
+	REG_D17 = 17
+	REG_D18 = 18
+	REG_D19 = 19
+	REG_D20 = 20
+	REG_D21 = 21
+	REG_D22 = 22
+	REG_D23 = 23
+	REG_D24 = 24
+	REG_D25 = 25
+	REG_D26 = 26
+	REG_D27 = 27
+	REG_D28 = 28
+	REG_D29 = 29
+	REG_D30 = 30
+	REG_D31 = 31
+)
+
 // Condition codes for B.cond / CSET
 const (
 	COND_EQ = 0x0 // equal
@@ -306,6 +375,27 @@ func (g *CodeGen) emitLdrb(rt, rn int, offset int) {
 	}
 }
 
+// emitLdr32 emits LDR Wt, [Xn, #offset] (zero-extend 32-bit word)
+func (g *CodeGen) emitLdr32(rt, rn int, offset int) {
+	if offset == 0 {
+		inst := uint32(0xB9400000) | (uint32(rn&0x1f) << 5) | uint32(rt&0x1f)
+		g.EmitArm64(inst)
+	} else if offset > 0 && offset%4 == 0 && offset/4 < 4096 {
+		uimm := uint32(offset / 4)
+		inst := uint32(0xB9400000) | (uimm << 10) | (uint32(rn&0x1f) << 5) | uint32(rt&0x1f)
+		g.EmitArm64(inst)
+	} else if offset >= -256 && offset <= 255 {
+		simm9 := uint32(offset) & 0x1FF
+		inst := uint32(0xB8400000) | (simm9 << 12) | (uint32(rn&0x1f) << 5) | uint32(rt&0x1f)
+		g.EmitArm64(inst)
+	} else {
+		g.EmitLoadImm64Compact(REG_X16, uint64(int64(offset)))
+		g.EmitAddRR(REG_X16, rn, REG_X16)
+		inst := uint32(0xB9400000) | (uint32(REG_X16&0x1f) << 5) | uint32(rt&0x1f)
+		g.EmitArm64(inst)
+	}
+}
+
 // emitStrb emits STRB Wt, [Xn, #offset]
 func (g *CodeGen) emitStrb(rt, rn int, offset int) {
 	if offset >= 0 && offset < 4096 {
@@ -319,6 +409,27 @@ func (g *CodeGen) emitStrb(rt, rn int, offset int) {
 		g.EmitLoadImm64Compact(REG_X16, uint64(int64(offset)))
 		g.EmitAddRR(REG_X16, rn, REG_X16)
 		inst := uint32(0x39000000) | (uint32(REG_X16&0x1f) << 5) | uint32(rt&0x1f)
+		g.EmitArm64(inst)
+	}
+}
+
+// emitStr32 emits STR Wt, [Xn, #offset]
+func (g *CodeGen) emitStr32(rt, rn int, offset int) {
+	if offset == 0 {
+		inst := uint32(0xB9000000) | (uint32(rn&0x1f) << 5) | uint32(rt&0x1f)
+		g.EmitArm64(inst)
+	} else if offset > 0 && offset%4 == 0 && offset/4 < 4096 {
+		uimm := uint32(offset / 4)
+		inst := uint32(0xB9000000) | (uimm << 10) | (uint32(rn&0x1f) << 5) | uint32(rt&0x1f)
+		g.EmitArm64(inst)
+	} else if offset >= -256 && offset <= 255 {
+		simm9 := uint32(offset) & 0x1FF
+		inst := uint32(0xB8000000) | (simm9 << 12) | (uint32(rn&0x1f) << 5) | uint32(rt&0x1f)
+		g.EmitArm64(inst)
+	} else {
+		g.EmitLoadImm64Compact(REG_X16, uint64(int64(offset)))
+		g.EmitAddRR(REG_X16, rn, REG_X16)
+		inst := uint32(0xB9000000) | (uint32(REG_X16&0x1f) << 5) | uint32(rt&0x1f)
 		g.EmitArm64(inst)
 	}
 }
@@ -415,6 +526,12 @@ func (g *CodeGen) emitUxtb(rd, rn int) {
 	g.EmitArm64(inst)
 }
 
+// emitSxtb emits SXTB Xd, Xn (sign-extend byte)
+func (g *CodeGen) emitSxtb(rd, rn int) {
+	inst := uint32(0x93401C00) | (uint32(rn&0x1f) << 5) | uint32(rd&0x1f)
+	g.EmitArm64(inst)
+}
+
 // emitUxth emits UXTH Xd, Xn (zero-extend halfword)
 func (g *CodeGen) emitUxth(rd, rn int) {
 	// UXTH Wd, Wn = UBFM Wd, Wn, #0, #15
@@ -441,6 +558,142 @@ func (g *CodeGen) emitSxtw(rd, rn int) {
 func (g *CodeGen) emitUxtw(rd, rn int) {
 	// Use 32-bit ORR: MOV Wd, Wn = ORR Wd, WZR, Wn (zero-extends)
 	inst := uint32(0x2A0003E0) | (uint32(rn&0x1f) << 16) | uint32(rd&0x1f)
+	g.EmitArm64(inst)
+}
+
+// === Floating-point register moves ===
+
+func (g *CodeGen) emitFmovDFromX(fd, xn int) {
+	inst := uint32(0x9E670000) | (uint32(xn&0x1f) << 5) | uint32(fd&0x1f)
+	g.EmitArm64(inst)
+}
+
+func (g *CodeGen) emitFmovXFromD(xd, fn int) {
+	inst := uint32(0x9E660000) | (uint32(fn&0x1f) << 5) | uint32(xd&0x1f)
+	g.EmitArm64(inst)
+}
+
+func (g *CodeGen) emitFmovSFromW(fs, wn int) {
+	inst := uint32(0x1E270000) | (uint32(wn&0x1f) << 5) | uint32(fs&0x1f)
+	g.EmitArm64(inst)
+}
+
+func (g *CodeGen) emitFmovWFromS(wd, fn int) {
+	inst := uint32(0x1E260000) | (uint32(fn&0x1f) << 5) | uint32(wd&0x1f)
+	g.EmitArm64(inst)
+}
+
+// === Floating-point arithmetic ===
+
+func (g *CodeGen) emitFaddD(fd, fn, fm int) {
+	inst := uint32(0x1E602800) | (uint32(fm&0x1f) << 16) | (uint32(fn&0x1f) << 5) | uint32(fd&0x1f)
+	g.EmitArm64(inst)
+}
+
+func (g *CodeGen) emitFaddS(fd, fn, fm int) {
+	inst := uint32(0x1E202800) | (uint32(fm&0x1f) << 16) | (uint32(fn&0x1f) << 5) | uint32(fd&0x1f)
+	g.EmitArm64(inst)
+}
+
+func (g *CodeGen) emitFsubD(fd, fn, fm int) {
+	inst := uint32(0x1E603800) | (uint32(fm&0x1f) << 16) | (uint32(fn&0x1f) << 5) | uint32(fd&0x1f)
+	g.EmitArm64(inst)
+}
+
+func (g *CodeGen) emitFsubS(fd, fn, fm int) {
+	inst := uint32(0x1E203800) | (uint32(fm&0x1f) << 16) | (uint32(fn&0x1f) << 5) | uint32(fd&0x1f)
+	g.EmitArm64(inst)
+}
+
+func (g *CodeGen) emitFmulD(fd, fn, fm int) {
+	inst := uint32(0x1E600800) | (uint32(fm&0x1f) << 16) | (uint32(fn&0x1f) << 5) | uint32(fd&0x1f)
+	g.EmitArm64(inst)
+}
+
+func (g *CodeGen) emitFmulS(fd, fn, fm int) {
+	inst := uint32(0x1E200800) | (uint32(fm&0x1f) << 16) | (uint32(fn&0x1f) << 5) | uint32(fd&0x1f)
+	g.EmitArm64(inst)
+}
+
+func (g *CodeGen) emitFdivD(fd, fn, fm int) {
+	inst := uint32(0x1E601800) | (uint32(fm&0x1f) << 16) | (uint32(fn&0x1f) << 5) | uint32(fd&0x1f)
+	g.EmitArm64(inst)
+}
+
+func (g *CodeGen) emitFdivS(fd, fn, fm int) {
+	inst := uint32(0x1E201800) | (uint32(fm&0x1f) << 16) | (uint32(fn&0x1f) << 5) | uint32(fd&0x1f)
+	g.EmitArm64(inst)
+}
+
+func (g *CodeGen) emitFnegD(fd, fn int) {
+	inst := uint32(0x1E614000) | (uint32(fn&0x1f) << 5) | uint32(fd&0x1f)
+	g.EmitArm64(inst)
+}
+
+func (g *CodeGen) emitFnegS(fd, fn int) {
+	inst := uint32(0x1E214000) | (uint32(fn&0x1f) << 5) | uint32(fd&0x1f)
+	g.EmitArm64(inst)
+}
+
+func (g *CodeGen) emitFcmpD(fn, fm int) {
+	inst := uint32(0x1E602000) | (uint32(fm&0x1f) << 16) | (uint32(fn&0x1f) << 5)
+	g.EmitArm64(inst)
+}
+
+func (g *CodeGen) emitFcmpS(fn, fm int) {
+	inst := uint32(0x1E202000) | (uint32(fm&0x1f) << 16) | (uint32(fn&0x1f) << 5)
+	g.EmitArm64(inst)
+}
+
+// === Floating-point conversions ===
+
+func (g *CodeGen) emitScvtfDFromX(fd, xn int) {
+	inst := uint32(0x9E620000) | (uint32(xn&0x1f) << 5) | uint32(fd&0x1f)
+	g.EmitArm64(inst)
+}
+
+func (g *CodeGen) emitUcvtfDFromX(fd, xn int) {
+	inst := uint32(0x9E630000) | (uint32(xn&0x1f) << 5) | uint32(fd&0x1f)
+	g.EmitArm64(inst)
+}
+
+func (g *CodeGen) emitScvtfSFromW(fd, wn int) {
+	inst := uint32(0x1E220000) | (uint32(wn&0x1f) << 5) | uint32(fd&0x1f)
+	g.EmitArm64(inst)
+}
+
+func (g *CodeGen) emitUcvtfSFromW(fd, wn int) {
+	inst := uint32(0x1E230000) | (uint32(wn&0x1f) << 5) | uint32(fd&0x1f)
+	g.EmitArm64(inst)
+}
+
+func (g *CodeGen) emitFcvtzsXFromD(xd, fn int) {
+	inst := uint32(0x9E780000) | (uint32(fn&0x1f) << 5) | uint32(xd&0x1f)
+	g.EmitArm64(inst)
+}
+
+func (g *CodeGen) emitFcvtzuXFromD(xd, fn int) {
+	inst := uint32(0x9E790000) | (uint32(fn&0x1f) << 5) | uint32(xd&0x1f)
+	g.EmitArm64(inst)
+}
+
+func (g *CodeGen) emitFcvtzsWFromS(wd, fn int) {
+	inst := uint32(0x1E380000) | (uint32(fn&0x1f) << 5) | uint32(wd&0x1f)
+	g.EmitArm64(inst)
+}
+
+func (g *CodeGen) emitFcvtzuWFromS(wd, fn int) {
+	inst := uint32(0x1E390000) | (uint32(fn&0x1f) << 5) | uint32(wd&0x1f)
+	g.EmitArm64(inst)
+}
+
+func (g *CodeGen) emitFcvtSToD(fd, fn int) {
+	inst := uint32(0x1E22C000) | (uint32(fn&0x1f) << 5) | uint32(fd&0x1f)
+	g.EmitArm64(inst)
+}
+
+func (g *CodeGen) emitFcvtDToS(fd, fn int) {
+	inst := uint32(0x1E624000) | (uint32(fn&0x1f) << 5) | uint32(fd&0x1f)
 	g.EmitArm64(inst)
 }
 

--- a/std/compiler/backend/aarch64/backend_aarch64.go
+++ b/std/compiler/backend/aarch64/backend_aarch64.go
@@ -509,10 +509,12 @@ func floatCompareCondArm64(op ir.Opcode) int {
 	case ir.OP_NEQ, ir.OP_JMP_NEQ:
 		return COND_NE
 	case ir.OP_LT, ir.OP_JMP_LT:
+		// Ordered LT after FCMP must stay false for NaN; COND_LT (N!=V) would be true for NaN.
 		return COND_MI
 	case ir.OP_GT, ir.OP_JMP_GT:
 		return COND_GT
 	case ir.OP_LEQ, ir.OP_JMP_LEQ:
+		// Ordered LE after FCMP must stay false for NaN; COND_LE (Z==1 || N!=V) would be true for NaN.
 		return COND_LS
 	case ir.OP_GEQ, ir.OP_JMP_GEQ:
 		return COND_GE

--- a/std/compiler/backend/aarch64/backend_aarch64.go
+++ b/std/compiler/backend/aarch64/backend_aarch64.go
@@ -140,6 +140,10 @@ func (g *CodeGen) compileInstArm64(inst ir.Inst) {
 	switch inst.Op {
 	case ir.OP_CONST_I64:
 		g.compileConstI64Arm64(inst.Val)
+	case ir.OP_CONST_F32:
+		g.compileConstF32Arm64(inst.Name)
+	case ir.OP_CONST_F64:
+		g.compileConstF64Arm64(inst.Name)
 	case ir.OP_CONST_BOOL:
 		if inst.Arg != 0 {
 			g.compileConstI64Arm64(1)
@@ -174,27 +178,59 @@ func (g *CodeGen) compileInstArm64(inst ir.Inst) {
 		g.opPush(REG_X0)
 
 	case ir.OP_ADD, ir.OP_SUB, ir.OP_MUL, ir.OP_DIV, ir.OP_MOD:
-		g.compileBinOpArm64(inst.Op)
+		if isFloatTypeNameArm64(inst.Name) {
+			g.compileFloatBinOpArm64(inst.Op, inst.Name)
+		} else {
+			g.compileBinOpArm64(inst.Op)
+		}
 	case ir.OP_NEG:
-		g.opPop(REG_X0)
-		g.emitNeg(REG_X0, REG_X0)
-		g.opPush(REG_X0)
+		if isFloatTypeNameArm64(inst.Name) {
+			g.compileFloatNegArm64(inst.Name)
+		} else {
+			g.opPop(REG_X0)
+			g.emitNeg(REG_X0, REG_X0)
+			g.opPush(REG_X0)
+		}
 
 	case ir.OP_AND, ir.OP_OR, ir.OP_XOR, ir.OP_SHL, ir.OP_SHR:
 		g.compileBinOpArm64(inst.Op)
 
 	case ir.OP_EQ:
-		g.compileCompareArm64(COND_EQ)
+		if isFloatTypeNameArm64(inst.Name) {
+			g.compileFloatCompareArm64(inst.Op, inst.Name)
+		} else {
+			g.compileCompareArm64(COND_EQ)
+		}
 	case ir.OP_NEQ:
-		g.compileCompareArm64(COND_NE)
+		if isFloatTypeNameArm64(inst.Name) {
+			g.compileFloatCompareArm64(inst.Op, inst.Name)
+		} else {
+			g.compileCompareArm64(COND_NE)
+		}
 	case ir.OP_LT:
-		g.compileCompareArm64(COND_LT)
+		if isFloatTypeNameArm64(inst.Name) {
+			g.compileFloatCompareArm64(inst.Op, inst.Name)
+		} else {
+			g.compileCompareArm64(COND_LT)
+		}
 	case ir.OP_GT:
-		g.compileCompareArm64(COND_GT)
+		if isFloatTypeNameArm64(inst.Name) {
+			g.compileFloatCompareArm64(inst.Op, inst.Name)
+		} else {
+			g.compileCompareArm64(COND_GT)
+		}
 	case ir.OP_LEQ:
-		g.compileCompareArm64(COND_LE)
+		if isFloatTypeNameArm64(inst.Name) {
+			g.compileFloatCompareArm64(inst.Op, inst.Name)
+		} else {
+			g.compileCompareArm64(COND_LE)
+		}
 	case ir.OP_GEQ:
-		g.compileCompareArm64(COND_GE)
+		if isFloatTypeNameArm64(inst.Name) {
+			g.compileFloatCompareArm64(inst.Op, inst.Name)
+		} else {
+			g.compileCompareArm64(COND_GE)
+		}
 
 	case ir.OP_NOT:
 		g.opPop(REG_X0)
@@ -221,17 +257,41 @@ func (g *CodeGen) compileInstArm64(inst ir.Inst) {
 		fixup := g.emitBCond(COND_EQ)
 		g.jumpFixups = append(g.jumpFixups, JumpFixup{fixup, inst.Arg, 0, 0})
 	case ir.OP_JMP_EQ:
-		g.compileCompareJumpArm64(COND_EQ, inst.Arg)
+		if isFloatTypeNameArm64(inst.Name) {
+			g.compileFloatCompareJumpArm64(inst.Op, inst.Arg, inst.Name)
+		} else {
+			g.compileCompareJumpArm64(COND_EQ, inst.Arg)
+		}
 	case ir.OP_JMP_NEQ:
-		g.compileCompareJumpArm64(COND_NE, inst.Arg)
+		if isFloatTypeNameArm64(inst.Name) {
+			g.compileFloatCompareJumpArm64(inst.Op, inst.Arg, inst.Name)
+		} else {
+			g.compileCompareJumpArm64(COND_NE, inst.Arg)
+		}
 	case ir.OP_JMP_LT:
-		g.compileCompareJumpArm64(COND_LT, inst.Arg)
+		if isFloatTypeNameArm64(inst.Name) {
+			g.compileFloatCompareJumpArm64(inst.Op, inst.Arg, inst.Name)
+		} else {
+			g.compileCompareJumpArm64(COND_LT, inst.Arg)
+		}
 	case ir.OP_JMP_GT:
-		g.compileCompareJumpArm64(COND_GT, inst.Arg)
+		if isFloatTypeNameArm64(inst.Name) {
+			g.compileFloatCompareJumpArm64(inst.Op, inst.Arg, inst.Name)
+		} else {
+			g.compileCompareJumpArm64(COND_GT, inst.Arg)
+		}
 	case ir.OP_JMP_LEQ:
-		g.compileCompareJumpArm64(COND_LE, inst.Arg)
+		if isFloatTypeNameArm64(inst.Name) {
+			g.compileFloatCompareJumpArm64(inst.Op, inst.Arg, inst.Name)
+		} else {
+			g.compileCompareJumpArm64(COND_LE, inst.Arg)
+		}
 	case ir.OP_JMP_GEQ:
-		g.compileCompareJumpArm64(COND_GE, inst.Arg)
+		if isFloatTypeNameArm64(inst.Name) {
+			g.compileFloatCompareJumpArm64(inst.Op, inst.Arg, inst.Name)
+		} else {
+			g.compileCompareJumpArm64(COND_GE, inst.Arg)
+		}
 
 	case ir.OP_CALL:
 		g.compileCallArm64(inst)
@@ -254,7 +314,7 @@ func (g *CodeGen) compileInstArm64(inst ir.Inst) {
 		g.compileCapArm64(inst)
 
 	case ir.OP_CONVERT:
-		g.compileConvertArm64(inst.Name)
+		g.compileConvertArm64(inst)
 
 	case ir.OP_IFACE_BOX:
 		g.compileIfaceBoxArm64(inst)
@@ -282,6 +342,26 @@ func (g *CodeGen) compileInstArm64(inst ir.Inst) {
 func (g *CodeGen) compileConstI64Arm64(val int64) {
 	g.prepareForClobber(REG_X0)
 	g.EmitLoadImm64Compact(REG_X0, uint64(val))
+	g.opPush(REG_X0)
+}
+
+func (g *CodeGen) compileConstF32Arm64(lit string) {
+	g.prepareForClobber(REG_X0)
+	bits, ok := parseFloatLiteralBitsArm64(lit)
+	if !ok {
+		bits = 0
+	}
+	g.EmitLoadImm64Compact(REG_X0, uint64(float32BitsFromFloat64Bits(bits)))
+	g.opPush(REG_X0)
+}
+
+func (g *CodeGen) compileConstF64Arm64(lit string) {
+	g.prepareForClobber(REG_X0)
+	bits, ok := parseFloatLiteralBitsArm64(lit)
+	if !ok {
+		bits = 0
+	}
+	g.EmitLoadImm64Compact(REG_X0, bits)
 	g.opPush(REG_X0)
 }
 
@@ -418,6 +498,86 @@ func (g *CodeGen) compileBinOpArm64(op ir.Opcode) {
 	g.opPush(REG_X1)
 }
 
+func isFloatTypeNameArm64(name string) bool {
+	return name == "float32" || name == "float64"
+}
+
+func floatCompareCondArm64(op ir.Opcode) int {
+	switch op {
+	case ir.OP_EQ, ir.OP_JMP_EQ:
+		return COND_EQ
+	case ir.OP_NEQ, ir.OP_JMP_NEQ:
+		return COND_NE
+	case ir.OP_LT, ir.OP_JMP_LT:
+		return COND_MI
+	case ir.OP_GT, ir.OP_JMP_GT:
+		return COND_GT
+	case ir.OP_LEQ, ir.OP_JMP_LEQ:
+		return COND_LS
+	case ir.OP_GEQ, ir.OP_JMP_GEQ:
+		return COND_GE
+	default:
+		panic("ICE: unsupported float compare opcode")
+	}
+}
+
+func (g *CodeGen) compileFloatBinOpArm64(op ir.Opcode, floatKind string) {
+	g.opPop(REG_X0)
+	g.opPop(REG_X1)
+
+	if floatKind == "float32" {
+		g.emitFmovSFromW(REG_S0, REG_X1)
+		g.emitFmovSFromW(REG_S1, REG_X0)
+		switch op {
+		case ir.OP_ADD:
+			g.emitFaddS(REG_S0, REG_S0, REG_S1)
+		case ir.OP_SUB:
+			g.emitFsubS(REG_S0, REG_S0, REG_S1)
+		case ir.OP_MUL:
+			g.emitFmulS(REG_S0, REG_S0, REG_S1)
+		case ir.OP_DIV:
+			g.emitFdivS(REG_S0, REG_S0, REG_S1)
+		default:
+			panic("ICE: unsupported float32 binop")
+		}
+		g.emitFmovWFromS(REG_X1, REG_S0)
+		g.opPush(REG_X1)
+		return
+	}
+
+	g.emitFmovDFromX(REG_D0, REG_X1)
+	g.emitFmovDFromX(REG_D1, REG_X0)
+	switch op {
+	case ir.OP_ADD:
+		g.emitFaddD(REG_D0, REG_D0, REG_D1)
+	case ir.OP_SUB:
+		g.emitFsubD(REG_D0, REG_D0, REG_D1)
+	case ir.OP_MUL:
+		g.emitFmulD(REG_D0, REG_D0, REG_D1)
+	case ir.OP_DIV:
+		g.emitFdivD(REG_D0, REG_D0, REG_D1)
+	default:
+		panic("ICE: unsupported float64 binop")
+	}
+	g.emitFmovXFromD(REG_X1, REG_D0)
+	g.opPush(REG_X1)
+}
+
+func (g *CodeGen) compileFloatNegArm64(floatKind string) {
+	g.opPop(REG_X0)
+	if floatKind == "float32" {
+		g.emitFmovSFromW(REG_S0, REG_X0)
+		g.emitFnegS(REG_S0, REG_S0)
+		g.emitFmovWFromS(REG_X0, REG_S0)
+		g.opPush(REG_X0)
+		return
+	}
+	g.emitFmovDFromX(REG_D0, REG_X0)
+	g.emitFnegD(REG_D0, REG_D0)
+	g.emitFmovXFromD(REG_X0, REG_D0)
+	g.opPush(REG_X0)
+}
+
 // === Comparison operations ===
 
 func (g *CodeGen) compileCompareArm64(cond int) {
@@ -434,6 +594,39 @@ func (g *CodeGen) compileCompareJumpArm64(cond int, label int) {
 	g.emitCmpRR(REG_X1, REG_X0)
 	g.Flush()
 	fixup := g.emitBCond(cond)
+	g.jumpFixups = append(g.jumpFixups, JumpFixup{fixup, label, 0, 0})
+}
+
+func (g *CodeGen) compileFloatCompareArm64(op ir.Opcode, floatKind string) {
+	g.opPop(REG_X0)
+	g.opPop(REG_X1)
+	if floatKind == "float32" {
+		g.emitFmovSFromW(REG_S0, REG_X1)
+		g.emitFmovSFromW(REG_S1, REG_X0)
+		g.emitFcmpS(REG_S0, REG_S1)
+	} else {
+		g.emitFmovDFromX(REG_D0, REG_X1)
+		g.emitFmovDFromX(REG_D1, REG_X0)
+		g.emitFcmpD(REG_D0, REG_D1)
+	}
+	g.emitCset(REG_X1, floatCompareCondArm64(op))
+	g.opPush(REG_X1)
+}
+
+func (g *CodeGen) compileFloatCompareJumpArm64(op ir.Opcode, label int, floatKind string) {
+	g.opPop(REG_X0)
+	g.opPop(REG_X1)
+	if floatKind == "float32" {
+		g.emitFmovSFromW(REG_S0, REG_X1)
+		g.emitFmovSFromW(REG_S1, REG_X0)
+		g.emitFcmpS(REG_S0, REG_S1)
+	} else {
+		g.emitFmovDFromX(REG_D0, REG_X1)
+		g.emitFmovDFromX(REG_D1, REG_X0)
+		g.emitFcmpD(REG_D0, REG_D1)
+	}
+	g.Flush()
+	fixup := g.emitBCond(floatCompareCondArm64(op))
 	g.jumpFixups = append(g.jumpFixups, JumpFixup{fixup, label, 0, 0})
 }
 
@@ -926,6 +1119,8 @@ func (g *CodeGen) compileLoadArm64(inst ir.Inst) {
 	if ir.IsNonNilMemoryBase(inst.Name) {
 		if size == 1 {
 			g.emitLdrb(REG_X0, REG_X1, offset)
+		} else if size == 4 {
+			g.emitLdr32(REG_X0, REG_X1, offset)
 		} else {
 			g.emitLdr(REG_X0, REG_X1, offset)
 		}
@@ -941,6 +1136,8 @@ func (g *CodeGen) compileLoadArm64(inst ir.Inst) {
 	g.patchArm64BCondAt(loadFixup, len(g.code))
 	if size == 1 {
 		g.emitLdrb(REG_X0, REG_X1, offset)
+	} else if size == 4 {
+		g.emitLdr32(REG_X0, REG_X1, offset)
 	} else {
 		g.emitLdr(REG_X0, REG_X1, offset)
 	}
@@ -955,6 +1152,8 @@ func (g *CodeGen) compileStoreArm64(inst ir.Inst) {
 	g.opPop(REG_X0) // value
 	if size == 1 {
 		g.emitStrb(REG_X0, REG_X1, offset)
+	} else if size == 4 {
+		g.emitStr32(REG_X0, REG_X1, offset)
 	} else {
 		g.EmitStr(REG_X0, REG_X1, offset)
 	}
@@ -1033,42 +1232,424 @@ func (g *CodeGen) compileCapArm64(inst ir.Inst) {
 
 // === Type conversions ===
 
-func (g *CodeGen) compileConvertArm64(typeName string) {
+func normalizeIntWidthArm64(g *CodeGen, reg int, width int, signed bool) {
+	switch width {
+	case 1:
+		if signed {
+			g.emitSxtb(reg, reg)
+		} else {
+			g.emitUxtb(reg, reg)
+		}
+	case 2:
+		if signed {
+			g.emitSxth(reg, reg)
+		} else {
+			g.emitUxth(reg, reg)
+		}
+	case 4:
+		if signed {
+			g.emitSxtw(reg, reg)
+		} else {
+			g.emitUxtw(reg, reg)
+		}
+	}
+}
+
+func lowerFloatSrcToDArm64(g *CodeGen, srcKind int64) {
+	switch srcKind {
+	case ir.CONVERT_SRC_FLOAT32:
+		g.emitFmovSFromW(REG_S0, REG_X0)
+		g.emitFcvtSToD(REG_D0, REG_S0)
+	case ir.CONVERT_SRC_FLOAT64:
+		g.emitFmovDFromX(REG_D0, REG_X0)
+	default:
+		panic("ICE: expected float conversion source")
+	}
+}
+
+func (g *CodeGen) compileConvertArm64(inst ir.Inst) {
+	typeName := inst.Name
 	switch typeName {
 	case "string":
 		g.EmitCallPlaceholderArm64("runtime.BytesToString")
 	case "[]byte":
 		g.EmitCallPlaceholderArm64("runtime.StringToBytes")
 	case "int", "uintptr", "uint", "int64", "uint64":
-		// No-op
+		if inst.Val == ir.CONVERT_SRC_FLOAT32 || inst.Val == ir.CONVERT_SRC_FLOAT64 {
+			g.opPop(REG_X0)
+			lowerFloatSrcToDArm64(g, inst.Val)
+			if typeName == "uint" || typeName == "uintptr" || typeName == "uint64" {
+				g.emitFcvtzuXFromD(REG_X0, REG_D0)
+			} else {
+				g.emitFcvtzsXFromD(REG_X0, REG_D0)
+			}
+			g.opPush(REG_X0)
+		}
 	case "byte":
 		g.opPop(REG_X0)
+		if inst.Val == ir.CONVERT_SRC_FLOAT32 || inst.Val == ir.CONVERT_SRC_FLOAT64 {
+			lowerFloatSrcToDArm64(g, inst.Val)
+			g.emitFcvtzuXFromD(REG_X0, REG_D0)
+		}
 		g.emitUxtb(REG_X0, REG_X0)
 		g.opPush(REG_X0)
 	case "uint8":
 		g.opPop(REG_X0)
+		if inst.Val == ir.CONVERT_SRC_FLOAT32 || inst.Val == ir.CONVERT_SRC_FLOAT64 {
+			lowerFloatSrcToDArm64(g, inst.Val)
+			g.emitFcvtzuXFromD(REG_X0, REG_D0)
+		}
 		g.emitUxtb(REG_X0, REG_X0)
 		g.opPush(REG_X0)
 	case "int8":
 		g.opPop(REG_X0)
-		// TODO: sign-ext byte helper can be added when needed; keep narrowing semantics.
-		g.emitUxtb(REG_X0, REG_X0)
+		if inst.Val == ir.CONVERT_SRC_FLOAT32 || inst.Val == ir.CONVERT_SRC_FLOAT64 {
+			lowerFloatSrcToDArm64(g, inst.Val)
+			g.emitFcvtzsXFromD(REG_X0, REG_D0)
+		}
+		g.emitSxtb(REG_X0, REG_X0)
 		g.opPush(REG_X0)
 	case "uint16":
 		g.opPop(REG_X0)
+		if inst.Val == ir.CONVERT_SRC_FLOAT32 || inst.Val == ir.CONVERT_SRC_FLOAT64 {
+			lowerFloatSrcToDArm64(g, inst.Val)
+			g.emitFcvtzuXFromD(REG_X0, REG_D0)
+		}
 		g.emitUxth(REG_X0, REG_X0)
 		g.opPush(REG_X0)
 	case "int16":
 		g.opPop(REG_X0)
+		if inst.Val == ir.CONVERT_SRC_FLOAT32 || inst.Val == ir.CONVERT_SRC_FLOAT64 {
+			lowerFloatSrcToDArm64(g, inst.Val)
+			g.emitFcvtzsXFromD(REG_X0, REG_D0)
+		}
 		g.emitSxth(REG_X0, REG_X0)
 		g.opPush(REG_X0)
 	case "int32":
 		g.opPop(REG_X0)
+		if inst.Val == ir.CONVERT_SRC_FLOAT32 || inst.Val == ir.CONVERT_SRC_FLOAT64 {
+			lowerFloatSrcToDArm64(g, inst.Val)
+			g.emitFcvtzsXFromD(REG_X0, REG_D0)
+		}
 		g.emitSxtw(REG_X0, REG_X0)
 		g.opPush(REG_X0)
 	case "uint32":
 		g.opPop(REG_X0)
+		if inst.Val == ir.CONVERT_SRC_FLOAT32 || inst.Val == ir.CONVERT_SRC_FLOAT64 {
+			lowerFloatSrcToDArm64(g, inst.Val)
+			g.emitFcvtzuXFromD(REG_X0, REG_D0)
+		}
 		g.emitUxtw(REG_X0, REG_X0)
 		g.opPush(REG_X0)
+	case "float32":
+		g.opPop(REG_X0)
+		switch inst.Val {
+		case ir.CONVERT_SRC_FLOAT32:
+			g.opPush(REG_X0)
+		case ir.CONVERT_SRC_FLOAT64:
+			g.emitFmovDFromX(REG_D0, REG_X0)
+			g.emitFcvtDToS(REG_S0, REG_D0)
+			g.emitFmovWFromS(REG_X0, REG_S0)
+			g.opPush(REG_X0)
+		default:
+			signed := inst.Val != ir.CONVERT_SRC_UINT
+			width := inst.Width
+			if width <= 0 {
+				width = 8
+			}
+			normalizeIntWidthArm64(g, REG_X0, width, signed)
+			if signed {
+				g.emitScvtfDFromX(REG_D0, REG_X0)
+			} else {
+				g.emitUcvtfDFromX(REG_D0, REG_X0)
+			}
+			g.emitFcvtDToS(REG_S0, REG_D0)
+			g.emitFmovWFromS(REG_X0, REG_S0)
+			g.opPush(REG_X0)
+		}
+	case "float64":
+		g.opPop(REG_X0)
+		switch inst.Val {
+		case ir.CONVERT_SRC_FLOAT64:
+			g.opPush(REG_X0)
+		case ir.CONVERT_SRC_FLOAT32:
+			g.emitFmovSFromW(REG_S0, REG_X0)
+			g.emitFcvtSToD(REG_D0, REG_S0)
+			g.emitFmovXFromD(REG_X0, REG_D0)
+			g.opPush(REG_X0)
+		default:
+			signed := inst.Val != ir.CONVERT_SRC_UINT
+			width := inst.Width
+			if width <= 0 {
+				width = 8
+			}
+			normalizeIntWidthArm64(g, REG_X0, width, signed)
+			if signed {
+				g.emitScvtfDFromX(REG_D0, REG_X0)
+			} else {
+				g.emitUcvtfDFromX(REG_D0, REG_X0)
+			}
+			g.emitFmovXFromD(REG_X0, REG_D0)
+			g.opPush(REG_X0)
+		}
 	}
+}
+
+func roundShiftNearestEvenArm64(v uint64, shift uint) uint64 {
+	if shift == 0 {
+		return v
+	}
+	if shift >= 64 {
+		return 0
+	}
+	half := uint64(1) << (shift - 1)
+	mask := (uint64(1) << shift) - 1
+	out := v >> shift
+	rem := v & mask
+	if rem > half || (rem == half && (out&1) != 0) {
+		out++
+	}
+	return out
+}
+
+func float32BitsFromFloat64Bits(bits uint64) uint32 {
+	sign := uint32(bits >> 63)
+	exp := int((bits >> 52) & 0x7FF)
+	frac := bits & ((uint64(1) << 52) - 1)
+	if exp == 0x7FF {
+		if frac == 0 {
+			return (sign << 31) | (0xFF << 23)
+		}
+		nan := uint32(frac >> 29)
+		if nan == 0 {
+			nan = 1
+		}
+		return (sign << 31) | (0xFF << 23) | nan
+	}
+	if exp == 0 && frac == 0 {
+		return sign << 31
+	}
+
+	mant := frac
+	unbiased := exp - 1023
+	if exp != 0 {
+		mant = mant | (uint64(1) << 52)
+	} else {
+		unbiased = -1022
+	}
+
+	if unbiased > 127 {
+		return (sign << 31) | (0xFF << 23)
+	}
+	if unbiased < -149 {
+		return sign << 31
+	}
+
+	if unbiased >= -126 {
+		mant24 := roundShiftNearestEvenArm64(mant, 29)
+		if mant24 >= (uint64(1) << 24) {
+			mant24 = mant24 >> 1
+			unbiased++
+		}
+		if unbiased > 127 {
+			return (sign << 31) | (0xFF << 23)
+		}
+		return (sign << 31) | (uint32(unbiased+127) << 23) | uint32(mant24&0x7FFFFF)
+	}
+
+	shift := uint(-unbiased - 97)
+	mant23 := roundShiftNearestEvenArm64(mant, shift)
+	if mant23 >= (uint64(1) << 23) {
+		return (sign << 31) | (1 << 23)
+	}
+	return (sign << 31) | uint32(mant23)
+}
+
+func mul10CheckedArm64(v uint64) (uint64, bool) {
+	if v > ^uint64(0)/10 {
+		return 0, false
+	}
+	return v * 10, true
+}
+
+func parseFloatLiteralBitsArm64(s string) (uint64, bool) {
+	if len(s) == 0 {
+		return 0, false
+	}
+	i := 0
+	sign := uint64(0)
+	if s[i] == '+' || s[i] == '-' {
+		if s[i] == '-' {
+			sign = uint64(1) << 63
+		}
+		i++
+		if i >= len(s) {
+			return 0, false
+		}
+	}
+
+	mant := uint64(0)
+	exp10 := 0
+	sawDigit := false
+	sawDot := false
+	for i < len(s) {
+		ch := s[i]
+		if ch == '_' {
+			i++
+			continue
+		}
+		if ch == '.' {
+			if sawDot {
+				return 0, false
+			}
+			sawDot = true
+			i++
+			continue
+		}
+		if ch == 'e' || ch == 'E' {
+			break
+		}
+		if ch < '0' || ch > '9' {
+			return 0, false
+		}
+		var ok bool
+		mant, ok = mul10CheckedArm64(mant)
+		if !ok {
+			return 0, false
+		}
+		mant = mant + uint64(ch-'0')
+		if sawDot {
+			exp10--
+		}
+		sawDigit = true
+		i++
+	}
+	if !sawDigit {
+		return 0, false
+	}
+
+	if i < len(s) && (s[i] == 'e' || s[i] == 'E') {
+		i++
+		if i >= len(s) {
+			return 0, false
+		}
+		expNeg := false
+		if s[i] == '+' || s[i] == '-' {
+			expNeg = s[i] == '-'
+			i++
+		}
+		if i >= len(s) {
+			return 0, false
+		}
+		exp := 0
+		haveExpDigit := false
+		for i < len(s) {
+			ch := s[i]
+			if ch == '_' {
+				i++
+				continue
+			}
+			if ch < '0' || ch > '9' {
+				return 0, false
+			}
+			exp = exp*10 + int(ch-'0')
+			haveExpDigit = true
+			i++
+		}
+		if !haveExpDigit {
+			return 0, false
+		}
+		if expNeg {
+			exp10 = exp10 - exp
+		} else {
+			exp10 = exp10 + exp
+		}
+	}
+	if i != len(s) {
+		return 0, false
+	}
+	if mant == 0 {
+		return sign, true
+	}
+
+	num := mant
+	den := uint64(1)
+	for exp10 > 0 {
+		var ok bool
+		num, ok = mul10CheckedArm64(num)
+		if !ok {
+			return 0, false
+		}
+		exp10--
+	}
+	for exp10 < 0 {
+		var ok bool
+		den, ok = mul10CheckedArm64(den)
+		if !ok {
+			return 0, false
+		}
+		exp10++
+	}
+
+	exp2 := 0
+	for num < den {
+		if num > (^uint64(0) >> 1) {
+			return 0, false
+		}
+		num = num << 1
+		exp2--
+	}
+	for {
+		if den <= (^uint64(0) >> 1) {
+			if num >= (den << 1) {
+				den = den << 1
+				exp2++
+				continue
+			}
+		} else if (num >> 1) >= den {
+			num = (num + 1) >> 1
+			exp2++
+			continue
+		}
+		break
+	}
+
+	frac := num - den
+	mantBits := uint64(0)
+	bit := uint64(1) << 51
+	for bit != 0 {
+		if frac > (^uint64(0) >> 1) {
+			den = (den + 1) >> 1
+		} else {
+			frac = frac << 1
+		}
+		if frac >= den {
+			mantBits = mantBits | bit
+			frac = frac - den
+		}
+		bit = bit >> 1
+	}
+
+	round := frac
+	if round > (^uint64(0) >> 1) {
+		den = (den + 1) >> 1
+	} else {
+		round = round << 1
+	}
+	if round > den || (round == den && (mantBits&1) != 0) {
+		mantBits++
+		if mantBits == (uint64(1) << 52) {
+			mantBits = 0
+			exp2++
+		}
+	}
+
+	expBits := exp2 + 1023
+	if expBits <= 0 {
+		return sign, true
+	}
+	if expBits >= 0x7FF {
+		return sign | (uint64(0x7FF) << 52), true
+	}
+	return sign | (uint64(expBits) << 52) | mantBits, true
 }

--- a/std/compiler/backend/c/backend_c.go
+++ b/std/compiler/backend/c/backend_c.go
@@ -84,6 +84,52 @@ func cMethodNamesSorted(m map[string]string) []string {
 	return out
 }
 
+func cModuleNeedsFloatKinds(irmod *ir.IRModule) (bool, bool) {
+	needF32 := false
+	needF64 := false
+	markKind := func(kind ir.TypeKind) {
+		if kind == ir.TY_FLOAT32 {
+			needF32 = true
+		}
+		if kind == ir.TY_FLOAT64 {
+			needF64 = true
+		}
+	}
+	for _, g := range irmod.Globals {
+		if g.Type != nil {
+			markKind(g.Type.Kind)
+		}
+	}
+	for _, t := range irmod.Types {
+		if t != nil {
+			markKind(t.Kind)
+		}
+	}
+	for _, f := range irmod.Funcs {
+		for _, k := range f.ResultKinds {
+			markKind(k)
+		}
+		for _, l := range f.Locals {
+			markKind(l.FloatKind)
+		}
+		for _, in := range f.Code {
+			switch in.Op {
+			case ir.OP_CONST_F32:
+				needF32 = true
+			case ir.OP_CONST_F64:
+				needF64 = true
+			}
+			if in.Name == "float32" {
+				needF32 = true
+			}
+			if in.Name == "float64" {
+				needF64 = true
+			}
+		}
+	}
+	return needF32, needF64
+}
+
 func cMangleSymbol(name string) string {
 	hex := "0123456789abcdef"
 	bp := &strings.Builder{}
@@ -301,6 +347,91 @@ func cEmitSignedCompareJump(bp *strings.Builder, op ir.Opcode, label int) bool {
 	return true
 }
 
+func cFloatBitsHelpers(floatName string) (ctype string, unpack string, pack string, ok bool) {
+	switch floatName {
+	case "float32":
+		return "float", "rtg_bits_f32", "rtg_f32_bits", true
+	case "float64":
+		return "double", "rtg_bits_f64", "rtg_f64_bits", true
+	default:
+		return "", "", "", false
+	}
+}
+
+func cEmitFloatBinaryOp(bp *strings.Builder, op ir.Opcode, floatName string) bool {
+	ctype, unpack, pack, ok := cFloatBitsHelpers(floatName)
+	if !ok {
+		return false
+	}
+	var tok string
+	switch op {
+	case ir.OP_ADD:
+		tok = "+"
+	case ir.OP_SUB:
+		tok = "-"
+	case ir.OP_MUL:
+		tok = "*"
+	case ir.OP_DIV:
+		tok = "/"
+	default:
+		return false
+	}
+	cWritef(bp, "  a = rtg_pop(); c = rtg_pop(); rtg_push(%s((%s)%s(c) %s (%s)%s(a)));\n", pack, ctype, unpack, tok, ctype, unpack)
+	return true
+}
+
+func cEmitFloatComparePush(bp *strings.Builder, op ir.Opcode, floatName string) bool {
+	_, unpack, _, ok := cFloatBitsHelpers(floatName)
+	if !ok {
+		return false
+	}
+	var tok string
+	switch op {
+	case ir.OP_EQ:
+		tok = "=="
+	case ir.OP_NEQ:
+		tok = "!="
+	case ir.OP_LT:
+		tok = "<"
+	case ir.OP_GT:
+		tok = ">"
+	case ir.OP_LEQ:
+		tok = "<="
+	case ir.OP_GEQ:
+		tok = ">="
+	default:
+		return false
+	}
+	cWritef(bp, "  a = rtg_pop(); c = rtg_pop(); rtg_push((rtg_word)(%s(c) %s %s(a)));\n", unpack, tok, unpack)
+	return true
+}
+
+func cEmitFloatCompareJump(bp *strings.Builder, op ir.Opcode, label int, floatName string) bool {
+	_, unpack, _, ok := cFloatBitsHelpers(floatName)
+	if !ok {
+		return false
+	}
+	var tok string
+	switch op {
+	case ir.OP_JMP_EQ:
+		tok = "=="
+	case ir.OP_JMP_NEQ:
+		tok = "!="
+	case ir.OP_JMP_LT:
+		tok = "<"
+	case ir.OP_JMP_GT:
+		tok = ">"
+	case ir.OP_JMP_LEQ:
+		tok = "<="
+	case ir.OP_JMP_GEQ:
+		tok = ">="
+	default:
+		return false
+	}
+	cWritef(bp, "  a = rtg_pop(); c = rtg_pop(); if (%s(c) %s %s(a)) goto L_%d;\n", unpack, tok, unpack, label)
+	return true
+}
+
 const cRuntimeIntrinsicPtr = "  a = locals[0]; rtg_push((a == 0) ? 0 : rtg_load(a, RTG_WORD_BYTES));\n"
 
 const cRuntimeIntrinsicMakeSlice = `  {
@@ -362,7 +493,15 @@ func cEmitCallOp(bp *strings.Builder, in ir.Inst, funcIdx map[string]int, funcSy
 	return nil
 }
 
-func cEmitConvertOp(bp *strings.Builder, name string, funcSyms []string, bytesToStringIdx int, stringToBytesIdx int) {
+func cEmitConvertOp(bp *strings.Builder, in ir.Inst, funcSyms []string, bytesToStringIdx int, stringToBytesIdx int) {
+	name := in.Name
+	floatSrcExpr := ""
+	switch in.Val {
+	case ir.CONVERT_SRC_FLOAT32:
+		floatSrcExpr = "rtg_bits_f32(a)"
+	case ir.CONVERT_SRC_FLOAT64:
+		floatSrcExpr = "rtg_bits_f64(a)"
+	}
 	switch name {
 	case "string":
 		if bytesToStringIdx >= 0 {
@@ -372,18 +511,76 @@ func cEmitConvertOp(bp *strings.Builder, name string, funcSyms []string, bytesTo
 		if stringToBytesIdx >= 0 {
 			cEmitSymbolCall(bp, funcSyms[stringToBytesIdx])
 		}
+	case "float32":
+		switch in.Val {
+		case ir.CONVERT_SRC_FLOAT32:
+			bp.WriteString("  /* no-op conversion */\n")
+		case ir.CONVERT_SRC_FLOAT64:
+			bp.WriteString("  a = rtg_pop(); rtg_push(rtg_f32_bits((float)rtg_bits_f64(a)));\n")
+		case ir.CONVERT_SRC_UINT:
+			bp.WriteString("  a = rtg_pop(); rtg_push(rtg_f32_bits((float)(rtg_word)a));\n")
+		default:
+			bp.WriteString("  a = rtg_pop(); rtg_push(rtg_f32_bits((float)(rtg_sword)a));\n")
+		}
+	case "float64":
+		switch in.Val {
+		case ir.CONVERT_SRC_FLOAT64:
+			bp.WriteString("  /* no-op conversion */\n")
+		case ir.CONVERT_SRC_FLOAT32:
+			bp.WriteString("  a = rtg_pop(); rtg_push(rtg_f64_bits((double)rtg_bits_f32(a)));\n")
+		case ir.CONVERT_SRC_UINT:
+			bp.WriteString("  a = rtg_pop(); rtg_push(rtg_f64_bits((double)(rtg_word)a));\n")
+		default:
+			bp.WriteString("  a = rtg_pop(); rtg_push(rtg_f64_bits((double)(rtg_sword)a));\n")
+		}
 	case "byte", "uint8":
-		bp.WriteString("  a = rtg_pop(); rtg_push(a & 0xffu);\n")
+		if floatSrcExpr != "" {
+			cWritef(bp, "  a = rtg_pop(); rtg_push((rtg_word)(unsigned char)(%s));\n", floatSrcExpr)
+		} else {
+			bp.WriteString("  a = rtg_pop(); rtg_push(a & 0xffu);\n")
+		}
 	case "int8":
-		bp.WriteString("  a = rtg_pop(); rtg_push((rtg_word)(rtg_sword)(signed char)(unsigned char)a);\n")
+		if floatSrcExpr != "" {
+			cWritef(bp, "  a = rtg_pop(); rtg_push((rtg_word)(rtg_sword)(signed char)(%s));\n", floatSrcExpr)
+		} else {
+			bp.WriteString("  a = rtg_pop(); rtg_push((rtg_word)(rtg_sword)(signed char)(unsigned char)a);\n")
+		}
 	case "uint16":
-		bp.WriteString("  a = rtg_pop(); rtg_push(a & 0xffffu);\n")
+		if floatSrcExpr != "" {
+			cWritef(bp, "  a = rtg_pop(); rtg_push((rtg_word)(rtg_u16)(%s));\n", floatSrcExpr)
+		} else {
+			bp.WriteString("  a = rtg_pop(); rtg_push(a & 0xffffu);\n")
+		}
 	case "int16":
-		bp.WriteString("  a = rtg_pop(); rtg_push((rtg_word)(rtg_sword)(rtg_i16)(rtg_u16)a);\n")
+		if floatSrcExpr != "" {
+			cWritef(bp, "  a = rtg_pop(); rtg_push((rtg_word)(rtg_sword)(rtg_i16)(%s));\n", floatSrcExpr)
+		} else {
+			bp.WriteString("  a = rtg_pop(); rtg_push((rtg_word)(rtg_sword)(rtg_i16)(rtg_u16)a);\n")
+		}
 	case "int32":
-		bp.WriteString("  a = rtg_pop(); rtg_push((rtg_word)(rtg_sword)(rtg_i32)(rtg_u32)a);\n")
+		if floatSrcExpr != "" {
+			cWritef(bp, "  a = rtg_pop(); rtg_push((rtg_word)(rtg_sword)(rtg_i32)(%s));\n", floatSrcExpr)
+		} else {
+			bp.WriteString("  a = rtg_pop(); rtg_push((rtg_word)(rtg_sword)(rtg_i32)(rtg_u32)a);\n")
+		}
 	case "uint32":
-		bp.WriteString("  a = rtg_pop(); rtg_push((rtg_word)(rtg_u32)a);\n")
+		if floatSrcExpr != "" {
+			cWritef(bp, "  a = rtg_pop(); rtg_push((rtg_word)(rtg_u32)(%s));\n", floatSrcExpr)
+		} else {
+			bp.WriteString("  a = rtg_pop(); rtg_push((rtg_word)(rtg_u32)a);\n")
+		}
+	case "int", "int64":
+		if floatSrcExpr != "" {
+			cWritef(bp, "  a = rtg_pop(); rtg_push((rtg_word)(rtg_sword)(rtg_i64)(%s));\n", floatSrcExpr)
+		} else {
+			bp.WriteString("  /* no-op conversion */\n")
+		}
+	case "uint", "uint64", "uintptr":
+		if floatSrcExpr != "" {
+			cWritef(bp, "  a = rtg_pop(); rtg_push((rtg_word)(rtg_u64)(%s));\n", floatSrcExpr)
+		} else {
+			bp.WriteString("  /* no-op conversion */\n")
+		}
 	default:
 		bp.WriteString("  /* no-op conversion */\n")
 	}
@@ -756,7 +953,7 @@ static rtg_word rtg_load(rtg_word addr, int size) {
     int i;
     unsigned char* p = (unsigned char*)(rtg_size)addr;
     unsigned char* out = (unsigned char*)&v;
-    for (i = 0; i < RTG_WORD_BYTES; i++) out[i] = p[i];
+    for (i = 0; i < size; i++) out[i] = p[i];
     return v;
   }
 }
@@ -774,8 +971,32 @@ static void rtg_store(rtg_word addr, rtg_word v, int size) {
     int i;
     unsigned char* p = (unsigned char*)(rtg_size)addr;
     unsigned char* in = (unsigned char*)&v;
-    for (i = 0; i < RTG_WORD_BYTES; i++) p[i] = in[i];
+    for (i = 0; i < size; i++) p[i] = in[i];
   }
+}
+
+static rtg_word rtg_f32_bits(float v) {
+  union { float f; rtg_u32 u; } bits;
+  bits.f = v;
+  return (rtg_word)bits.u;
+}
+
+static float rtg_bits_f32(rtg_word v) {
+  union { float f; rtg_u32 u; } bits;
+  bits.u = (rtg_u32)v;
+  return bits.f;
+}
+
+static rtg_word rtg_f64_bits(double v) {
+  union { double f; rtg_u64 u; } bits;
+  bits.f = v;
+  return (rtg_word)bits.u;
+}
+
+static double rtg_bits_f64(rtg_word v) {
+  union { double f; rtg_u64 u; } bits;
+  bits.u = (rtg_u64)v;
+  return bits.f;
 }
 
 static int rtg_prefix(const char* s, const char* p) {
@@ -872,6 +1093,13 @@ func Generate(target *common.Target, irmod *ir.IRModule, outputPath string) erro
 	}
 	if bits != 16 && bits != 32 && bits != 64 {
 		return fmt.Errorf("invalid C profile: %d", bits)
+	}
+	needF32, needF64 := cModuleNeedsFloatKinds(irmod)
+	if needF32 && bits < 32 {
+		return fmt.Errorf("c/%d backend does not support float32 values; use c/32 or c/64", bits)
+	}
+	if needF64 && bits < 64 {
+		return fmt.Errorf("c/%d backend does not support float64 values; use c/64", bits)
 	}
 
 	wordBytes := bits / 8
@@ -1028,6 +1256,8 @@ func Generate(target *common.Target, irmod *ir.IRModule, outputPath string) erro
 	bp.WriteString("#endif\n")
 	cWritef(bp, "typedef %s rtg_sword;\n", signedWord)
 	cWritef(bp, "typedef %s rtg_word;\n", unsignedWord)
+	bp.WriteString("typedef signed long long rtg_i64;\n")
+	bp.WriteString("typedef unsigned long long rtg_u64;\n")
 	bp.WriteString("typedef signed short rtg_i16;\n")
 	bp.WriteString("typedef unsigned short rtg_u16;\n")
 	cWritef(bp, "typedef %s rtg_i32;\n", i32Type)
@@ -1210,7 +1440,9 @@ func Generate(target *common.Target, irmod *ir.IRModule, outputPath string) erro
 				needC = true
 				needT = true
 			case ir.OP_CONVERT:
-				if in.Name == "byte" || in.Name == "uint16" || in.Name == "int16" || in.Name == "int32" || in.Name == "uint32" {
+				if in.Name == "byte" || in.Name == "uint16" || in.Name == "int16" || in.Name == "int32" || in.Name == "uint32" ||
+					in.Name == "int" || in.Name == "uint" || in.Name == "int64" || in.Name == "uint64" || in.Name == "uintptr" ||
+					in.Name == "float32" || in.Name == "float64" || in.Val == ir.CONVERT_SRC_FLOAT32 || in.Val == ir.CONVERT_SRC_FLOAT64 {
 					needA = true
 				}
 			case ir.OP_IFACE_BOX:
@@ -1283,6 +1515,10 @@ func Generate(target *common.Target, irmod *ir.IRModule, outputPath string) erro
 			switch in.Op {
 			case ir.OP_CONST_I64:
 				cWritef(bp, "  rtg_push((rtg_word)((rtg_sword)%s));\n", cSignedLiteral(in.Val, bits))
+			case ir.OP_CONST_F32:
+				cWritef(bp, "  rtg_push(rtg_f32_bits((float)(%s)));\n", in.Name)
+			case ir.OP_CONST_F64:
+				cWritef(bp, "  rtg_push(rtg_f64_bits((double)(%s)));\n", in.Name)
 			case ir.OP_CONST_STR:
 				lit := becommon.DecodeStringLiteral(in.Name)
 				idx := litIdx[lit]
@@ -1315,17 +1551,29 @@ func Generate(target *common.Target, irmod *ir.IRModule, outputPath string) erro
 				bp.WriteString("  t = rtg_pop(); rtg_push(t); rtg_push(t);\n")
 
 			case ir.OP_ADD:
-				cEmitSignedBinaryOp(bp, in.Op)
+				if !cEmitFloatBinaryOp(bp, in.Op, in.Name) {
+					cEmitSignedBinaryOp(bp, in.Op)
+				}
 			case ir.OP_SUB:
-				cEmitSignedBinaryOp(bp, in.Op)
+				if !cEmitFloatBinaryOp(bp, in.Op, in.Name) {
+					cEmitSignedBinaryOp(bp, in.Op)
+				}
 			case ir.OP_MUL:
-				cEmitSignedBinaryOp(bp, in.Op)
+				if !cEmitFloatBinaryOp(bp, in.Op, in.Name) {
+					cEmitSignedBinaryOp(bp, in.Op)
+				}
 			case ir.OP_DIV:
-				bp.WriteString("  a = rtg_pop(); c = rtg_pop(); rtg_push((a == 0) ? 0 : (rtg_word)((rtg_sword)c / (rtg_sword)a));\n")
+				if !cEmitFloatBinaryOp(bp, in.Op, in.Name) {
+					bp.WriteString("  a = rtg_pop(); c = rtg_pop(); rtg_push((a == 0) ? 0 : (rtg_word)((rtg_sword)c / (rtg_sword)a));\n")
+				}
 			case ir.OP_MOD:
 				bp.WriteString("  a = rtg_pop(); c = rtg_pop(); rtg_push((a == 0) ? 0 : (rtg_word)((rtg_sword)c % (rtg_sword)a));\n")
 			case ir.OP_NEG:
-				bp.WriteString("  a = rtg_pop(); rtg_push((rtg_word)(-(rtg_sword)a));\n")
+				if _, unpack, pack, ok := cFloatBitsHelpers(in.Name); ok {
+					cWritef(bp, "  a = rtg_pop(); rtg_push(%s(-%s(a)));\n", pack, unpack)
+				} else {
+					bp.WriteString("  a = rtg_pop(); rtg_push((rtg_word)(-(rtg_sword)a));\n")
+				}
 			case ir.OP_AND:
 				bp.WriteString("  a = rtg_pop(); c = rtg_pop(); rtg_push(c & a);\n")
 			case ir.OP_OR:
@@ -1337,17 +1585,29 @@ func Generate(target *common.Target, irmod *ir.IRModule, outputPath string) erro
 			case ir.OP_SHR:
 				bp.WriteString("  a = rtg_pop(); c = rtg_pop(); rtg_push((rtg_word)(((rtg_sword)c) >> (a & RTG_SHIFT_MASK)));\n")
 			case ir.OP_EQ:
-				cEmitSignedComparePush(bp, in.Op)
+				if !cEmitFloatComparePush(bp, in.Op, in.Name) {
+					cEmitSignedComparePush(bp, in.Op)
+				}
 			case ir.OP_NEQ:
-				cEmitSignedComparePush(bp, in.Op)
+				if !cEmitFloatComparePush(bp, in.Op, in.Name) {
+					cEmitSignedComparePush(bp, in.Op)
+				}
 			case ir.OP_LT:
-				cEmitSignedComparePush(bp, in.Op)
+				if !cEmitFloatComparePush(bp, in.Op, in.Name) {
+					cEmitSignedComparePush(bp, in.Op)
+				}
 			case ir.OP_GT:
-				cEmitSignedComparePush(bp, in.Op)
+				if !cEmitFloatComparePush(bp, in.Op, in.Name) {
+					cEmitSignedComparePush(bp, in.Op)
+				}
 			case ir.OP_LEQ:
-				cEmitSignedComparePush(bp, in.Op)
+				if !cEmitFloatComparePush(bp, in.Op, in.Name) {
+					cEmitSignedComparePush(bp, in.Op)
+				}
 			case ir.OP_GEQ:
-				cEmitSignedComparePush(bp, in.Op)
+				if !cEmitFloatComparePush(bp, in.Op, in.Name) {
+					cEmitSignedComparePush(bp, in.Op)
+				}
 			case ir.OP_NOT:
 				bp.WriteString("  a = rtg_pop(); rtg_push((rtg_word)(a == 0));\n")
 
@@ -1391,17 +1651,29 @@ func Generate(target *common.Target, irmod *ir.IRModule, outputPath string) erro
 			case ir.OP_JMP_IF_NOT:
 				cWritef(bp, "  a = rtg_pop(); if (a == 0) goto L_%d;\n", in.Arg)
 			case ir.OP_JMP_EQ:
-				cEmitSignedCompareJump(bp, in.Op, in.Arg)
+				if !cEmitFloatCompareJump(bp, in.Op, in.Arg, in.Name) {
+					cEmitSignedCompareJump(bp, in.Op, in.Arg)
+				}
 			case ir.OP_JMP_NEQ:
-				cEmitSignedCompareJump(bp, in.Op, in.Arg)
+				if !cEmitFloatCompareJump(bp, in.Op, in.Arg, in.Name) {
+					cEmitSignedCompareJump(bp, in.Op, in.Arg)
+				}
 			case ir.OP_JMP_LT:
-				cEmitSignedCompareJump(bp, in.Op, in.Arg)
+				if !cEmitFloatCompareJump(bp, in.Op, in.Arg, in.Name) {
+					cEmitSignedCompareJump(bp, in.Op, in.Arg)
+				}
 			case ir.OP_JMP_GT:
-				cEmitSignedCompareJump(bp, in.Op, in.Arg)
+				if !cEmitFloatCompareJump(bp, in.Op, in.Arg, in.Name) {
+					cEmitSignedCompareJump(bp, in.Op, in.Arg)
+				}
 			case ir.OP_JMP_LEQ:
-				cEmitSignedCompareJump(bp, in.Op, in.Arg)
+				if !cEmitFloatCompareJump(bp, in.Op, in.Arg, in.Name) {
+					cEmitSignedCompareJump(bp, in.Op, in.Arg)
+				}
 			case ir.OP_JMP_GEQ:
-				cEmitSignedCompareJump(bp, in.Op, in.Arg)
+				if !cEmitFloatCompareJump(bp, in.Op, in.Arg, in.Name) {
+					cEmitSignedCompareJump(bp, in.Op, in.Arg)
+				}
 
 			case ir.OP_CALL:
 				if err := cEmitCallOp(bp, in, funcIdx, funcSyms); err != nil {
@@ -1420,7 +1692,7 @@ func Generate(target *common.Target, irmod *ir.IRModule, outputPath string) erro
 				bp.WriteString("  return;\n")
 
 			case ir.OP_CONVERT:
-				cEmitConvertOp(bp, in.Name, funcSyms, bytesToStringIdx, stringToBytesIdx)
+				cEmitConvertOp(bp, in, funcSyms, bytesToStringIdx, stringToBytesIdx)
 
 			case ir.OP_IFACE_BOX:
 				cWritef(bp, "  a = rtg_pop(); c = rtg_alloc((rtg_word)(2 * RTG_WORD_BYTES)); rtg_store(c, (rtg_word)%d, RTG_WORD_BYTES); rtg_store(c + RTG_WORD_BYTES, a, RTG_WORD_BYTES); rtg_push(c);\n", in.Arg)

--- a/std/compiler/backend/c/backend_c.go
+++ b/std/compiler/backend/c/backend_c.go
@@ -376,6 +376,7 @@ func cEmitFloatBinaryOp(bp *strings.Builder, op ir.Opcode, floatName string) boo
 	default:
 		return false
 	}
+	// The IR pushes lhs then rhs, so rtg_pop() yields rhs before lhs.
 	cWritef(bp, "  a = rtg_pop(); c = rtg_pop(); rtg_push(%s((%s)%s(c) %s (%s)%s(a)));\n", pack, ctype, unpack, tok, ctype, unpack)
 	return true
 }

--- a/std/compiler/backend/irprint/backend_ir.go
+++ b/std/compiler/backend/irprint/backend_ir.go
@@ -15,6 +15,8 @@ func opcodeName(op ir.Opcode) string {
 	switch op {
 	case ir.OP_CONST_I64:
 		return "const_i64"
+	case ir.OP_CONST_F32:
+		return "const_f32"
 	case ir.OP_CONST_F64:
 		return "const_f64"
 	case ir.OP_CONST_STR:
@@ -148,6 +150,8 @@ func typeKindName(k ir.TypeKind) string {
 		return "int32"
 	case ir.TY_INT:
 		return "int"
+	case ir.TY_FLOAT32:
+		return "float32"
 	case ir.TY_FLOAT64:
 		return "float64"
 	case ir.TY_UINTPTR:
@@ -433,7 +437,7 @@ func instArgs(inst ir.Inst, f *ir.IRFunc, irmod *ir.IRModule) string {
 	switch op {
 	case ir.OP_CONST_I64:
 		return " " + fmt.Sprintf("%d", val) + w
-	case ir.OP_CONST_F64:
+	case ir.OP_CONST_F32, ir.OP_CONST_F64:
 		if name != "" {
 			return " " + irQuote(name) + w
 		}
@@ -480,11 +484,17 @@ func instArgs(inst ir.Inst, f *ir.IRFunc, irmod *ir.IRModule) string {
 		if val != 0 {
 			s = s + " off=" + fmt.Sprintf("%d", val)
 		}
+		if name != "" {
+			s = s + " kind=" + irQuote(name)
+		}
 		return s
 	case ir.OP_STORE:
 		s := " size=" + fmt.Sprintf("%d", arg)
 		if val != 0 {
 			s = s + " off=" + fmt.Sprintf("%d", val)
+		}
+		if name != "" {
+			s = s + " kind=" + irQuote(name)
 		}
 		return s
 	case ir.OP_OFFSET:
@@ -514,6 +524,14 @@ func instArgs(inst ir.Inst, f *ir.IRFunc, irmod *ir.IRModule) string {
 		return " kind=" + fmt.Sprintf("%d", arg)
 	case ir.OP_CAP:
 		return ""
+	}
+	switch op {
+	case ir.OP_ADD, ir.OP_SUB, ir.OP_MUL, ir.OP_DIV, ir.OP_MOD, ir.OP_NEG,
+		ir.OP_EQ, ir.OP_NEQ, ir.OP_LT, ir.OP_GT, ir.OP_LEQ, ir.OP_GEQ,
+		ir.OP_JMP_EQ, ir.OP_JMP_NEQ, ir.OP_JMP_LT, ir.OP_JMP_GT, ir.OP_JMP_LEQ, ir.OP_JMP_GEQ:
+		if name != "" {
+			return " kind=" + irQuote(name) + w
+		}
 	}
 	if w != "" {
 		return w

--- a/std/compiler/binary/ir_binary_codec.go
+++ b/std/compiler/binary/ir_binary_codec.go
@@ -253,6 +253,7 @@ func WriteIRBinary(irmod *ir.IRModule, path string) error {
 			w.writeInt(typeIndex(typeIdx, l.Type))
 			w.writeInt(l.Index)
 			w.writeBool(l.Is64)
+			w.writeInt(int(l.FloatKind))
 			w.writeInt(l.Width)
 		}
 
@@ -528,6 +529,11 @@ func readIRFuncs(r *irBinReader, types []*ir.TypeInfo) ([]*ir.IRFunc, error) {
 			if err != nil {
 				return nil, err
 			}
+			floatKind, err := r.readInt()
+			if err != nil {
+				return nil, err
+			}
+			l.FloatKind = ir.TypeKind(floatKind)
 			l.Width, err = r.readInt()
 			if err != nil {
 				return nil, err

--- a/std/compiler/binary/ir_binary_codec.go
+++ b/std/compiler/binary/ir_binary_codec.go
@@ -11,7 +11,8 @@ import (
 
 const IrBinaryEnabled = true
 
-var irBinaryMagic = []byte{'R', 'T', 'G', 'I', 'R', 'B', '1', 0}
+var irBinaryMagic = []byte{'R', 'T', 'G', 'I', 'R', 'B', '2', 0}
+var irBinaryLegacyMagic = []byte{'R', 'T', 'G', 'I', 'R', 'B', '1', 0}
 
 type irBinWriter struct {
 	buf []byte
@@ -306,12 +307,19 @@ func WriteIRBinary(irmod *ir.IRModule, path string) error {
 }
 
 func readIRMagic(r *irBinReader) error {
+	legacyMatch := true
 	for i := 0; i < len(irBinaryMagic); i++ {
 		b, err := r.readByte()
 		if err != nil {
 			return err
 		}
+		if legacyMatch && b != irBinaryLegacyMagic[i] {
+			legacyMatch = false
+		}
 		if b != irBinaryMagic[i] {
+			if legacyMatch && i == len(irBinaryMagic)-1 {
+				return fmt.Errorf("unsupported IR binary version 1: local float_kind metadata requires version 2")
+			}
 			return fmt.Errorf("invalid IR binary magic")
 		}
 	}

--- a/std/compiler/binary/ir_text_codec.go
+++ b/std/compiler/binary/ir_text_codec.go
@@ -21,6 +21,7 @@ var typeKindNames = []string{
 	"BYTE",
 	"INT32",
 	"INT",
+	"FLOAT32",
 	"FLOAT64",
 	"UINTPTR",
 	"STRING",
@@ -36,6 +37,7 @@ var typeKindByName = map[string]ir.TypeKind{}
 
 var opcodeNames = []string{
 	"CONST_I64",
+	"CONST_F32",
 	"CONST_F64",
 	"CONST_STR",
 	"CONST_BOOL",
@@ -140,7 +142,7 @@ func opRequiresVal(op ir.Opcode) bool {
 
 func opRequiresName(op ir.Opcode) bool {
 	switch op {
-	case ir.OP_CONST_F64, ir.OP_CONST_STR, ir.OP_CALL, ir.OP_CALL_INTRINSIC, ir.OP_CONVERT, ir.OP_IFACE_CALL:
+	case ir.OP_CONST_F32, ir.OP_CONST_F64, ir.OP_CONST_STR, ir.OP_CALL, ir.OP_CALL_INTRINSIC, ir.OP_CONVERT, ir.OP_IFACE_CALL:
 		return true
 	}
 	return false
@@ -520,6 +522,12 @@ func WriteIRText(irmod *ir.IRModule, path string) error {
 				w.WriteString("true")
 			} else {
 				w.WriteString("false")
+			}
+			w.WriteString(" float_kind=")
+			if int(l.FloatKind) >= 0 && int(l.FloatKind) < len(typeKindNames) {
+				w.WriteString(typeKindNames[int(l.FloatKind)])
+			} else {
+				w.WriteString("VOID")
 			}
 			w.WriteString(" width=")
 			writeInt(w, l.Width)
@@ -1311,16 +1319,25 @@ func (d *textDecoder) consumeLocals(tokens []string) error {
 	if err != nil {
 		return err
 	}
+	floatKindRaw, err := requireAttr(attrs, "float_kind")
+	if err != nil {
+		return err
+	}
+	floatKind, ok := typeKindByName[floatKindRaw]
+	if !ok {
+		return fmt.Errorf("unknown float kind %q", floatKindRaw)
+	}
 	width, err := parseIntAttr(attrs, "width")
 	if err != nil {
 		return err
 	}
 	d.curFunc.locals = append(d.curFunc.locals, textLocalRec{
 		local: ir.IRLocal{
-			Name:  name,
-			Index: index,
-			Is64:  is64,
-			Width: width,
+			Name:      name,
+			Index:     index,
+			Is64:      is64,
+			FloatKind: floatKind,
+			Width:     width,
 		},
 		typeIdx: typeIdx,
 	})

--- a/std/compiler/binary/ir_text_codec.go
+++ b/std/compiler/binary/ir_text_codec.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	irTextMagicLine = "rtgir 2"
+	irTextMagicLine = "rtgir 3"
 )
 
 var typeKindNames = []string{
@@ -1563,9 +1563,15 @@ func (d *textDecoder) consumeMapEntry(block string, tokens []string) error {
 
 func (d *textDecoder) consumeTokens(tokens []string) error {
 	if !d.seenHeader {
-		if len(tokens) == 2 && tokens[0] == "rtgir" && tokens[1] == "2" {
-			d.seenHeader = true
-			return nil
+		if len(tokens) == 2 && tokens[0] == "rtgir" {
+			if tokens[1] == "3" {
+				d.seenHeader = true
+				return nil
+			}
+			if tokens[1] == "2" {
+				return fmt.Errorf("unsupported text IR version %q: local float_kind metadata requires %q", tokens[1], irTextMagicLine)
+			}
+			return fmt.Errorf("unsupported text IR version %q", tokens[1])
 		}
 		return fmt.Errorf("expected %q header", irTextMagicLine)
 	}

--- a/std/compiler/frontend/go/compiler.go
+++ b/std/compiler/frontend/go/compiler.go
@@ -683,7 +683,6 @@ func (c *Compiler) resolveStructSize(qualifiedType string) int {
 
 // typeElemSize returns storage size in bytes for values of typeName when used as
 // slice elements in this compiler's lowered representation.
-// Non-byte elements are pointer-sized handles to values.
 func (c *Compiler) typeElemSize(typeName string) int {
 	if typeName == "" {
 		return c.target.PtrSize
@@ -691,7 +690,10 @@ func (c *Compiler) typeElemSize(typeName string) int {
 	if typeName == "byte" {
 		return 1
 	}
-	if isFloatTypeName(typeName) {
+	if typeName == "float32" {
+		return 4
+	}
+	if typeName == "float64" {
 		return 8
 	}
 	return c.target.PtrSize
@@ -847,6 +849,17 @@ func (c *Compiler) resolveFieldSliceElemType(qualifiedType string, fieldName str
 }
 
 func splitBracketType(typeName string) (string, bool) {
+	if len(typeName) >= 3 && typeName[0] != '[' {
+		dotIdx := -1
+		for i := 0; i < len(typeName); i++ {
+			if typeName[i] == '.' {
+				dotIdx = i
+			}
+		}
+		if dotIdx >= 0 && dotIdx+1 < len(typeName) && typeName[dotIdx+1] == '[' {
+			typeName = typeName[dotIdx+1:]
+		}
+	}
 	if len(typeName) < 3 || typeName[0] != '[' {
 		return "", false
 	}
@@ -1424,7 +1437,7 @@ func (c *Compiler) convertSourceKind(node *Node) int64 {
 	if typeName == "" {
 		typeName = c.exprConcreteType(node)
 	}
-	if typeName == "" && node.Kind == NFloatLit {
+	if typeName == "" && c.isConstFloatExpr(node) {
 		typeName = "float64"
 	}
 	switch c.resolveStorageTypeName(typeName, 0) {
@@ -9934,7 +9947,8 @@ func (c *Compiler) decodeComptimeValue(raw uint64, typeNode *Node, eval *vm.Eval
 
 // qualifyTypeName qualifies a type name with a package path if not already qualified.
 func (c *Compiler) qualifyTypeName(typeName string, pkgPath string) string {
-	if typeName == "" || typeName == "string" || typeName == "int" || typeName == "bool" || typeName == "byte" || typeName == "error" || typeName == "interface{}" {
+	if typeName == "" || typeName == "string" || typeName == "int" || typeName == "bool" || typeName == "byte" ||
+		typeName == "float32" || typeName == "float64" || typeName == "error" || typeName == "interface{}" {
 		return typeName
 	}
 	// Unqualified names (pkgPath=="") are resolved relative to c.curPkg.
@@ -9989,6 +10003,7 @@ func (c *Compiler) qualifyTypeNameInner(typeName string, pkgPath string) string 
 	if len(typeName) > 1 && typeName[0] == '*' {
 		inner := typeName[1:len(typeName)]
 		if inner == "string" || inner == "int" || inner == "bool" || inner == "byte" ||
+			inner == "float32" || inner == "float64" ||
 			inner == "int8" || inner == "uint8" || inner == "int16" || inner == "uint16" ||
 			inner == "int32" || inner == "uint32" || inner == "int64" || inner == "uint64" ||
 			inner == "uint" || inner == "uintptr" || inner == "error" || inner == "interface{}" {
@@ -10645,6 +10660,16 @@ func (c *Compiler) compileIndexExpr(node *Node) {
 		return
 	}
 	elemSize := c.exprElemSize(node.X)
+	if node.X != nil && node.X.Kind == NIdent {
+		if idx, ok := c.lookupLocal(node.X.Name); ok && idx >= 0 && idx < len(c.curFunc.Locals) {
+			switch c.curFunc.Locals[idx].FloatKind {
+			case ir.TY_FLOAT32:
+				elemSize = 4
+			case ir.TY_FLOAT64:
+				elemSize = 8
+			}
+		}
+	}
 	c.compileExpr(node.X)
 	c.compileExpr(node.Y)
 	c.emit(ir.Inst{Op: ir.OP_INDEX_ADDR, Arg: elemSize})

--- a/std/compiler/frontend/go/compiler.go
+++ b/std/compiler/frontend/go/compiler.go
@@ -261,13 +261,11 @@ func CompileModule(target common.Target, mod *Module) (*ir.IRModule, []string) {
 					global.Type = t
 				}
 			} else if sym.Node != nil && sym.Node.X != nil {
-				switch sym.Node.X.Kind {
-				case NFloatLit:
+				switch c.exprConcreteType(sym.Node.X) {
+				case "float32":
+					global.Type = c.types["float32"]
+				case "float64":
 					global.Type = c.types["float64"]
-				case NIdent:
-					if sym2, ok := pkg.Symbols[sym.Node.X.Name]; ok && sym2.Kind == SymConst && sym2.Node != nil && c.isConstFloatExpr(sym2.Node.X) {
-						global.Type = c.types["float64"]
-					}
 				}
 			}
 			c.irmod.Globals = append(c.irmod.Globals, global)
@@ -353,6 +351,7 @@ func (c *Compiler) initBuiltinTypes() {
 	c.types["uint16"] = &ir.TypeInfo{Kind: ir.TY_INT32, Name: "uint16", Size: 2, Align: 2}
 	c.types["int32"] = &ir.TypeInfo{Kind: ir.TY_INT32, Name: "int32", Size: 4, Align: 4}
 	c.types["int"] = &ir.TypeInfo{Kind: ir.TY_INT, Name: "int", Size: 8, Align: 8}
+	c.types["float32"] = &ir.TypeInfo{Kind: ir.TY_FLOAT32, Name: "float32", Size: 4, Align: 4}
 	c.types["float64"] = &ir.TypeInfo{Kind: ir.TY_FLOAT64, Name: "float64", Size: 8, Align: 8}
 	c.types["uintptr"] = &ir.TypeInfo{Kind: ir.TY_UINTPTR, Name: "uintptr", Size: 8, Align: 8}
 	c.types["string"] = &ir.TypeInfo{Kind: ir.TY_STRING, Name: "string", Size: 16, Align: 8}
@@ -526,6 +525,9 @@ func (c *Compiler) lookupStructField(qualifiedType string, fieldName string) (*N
 
 func (c *Compiler) storageSizeForTypeName(typeName string) int {
 	typeName = c.resolveStorageTypeName(typeName, 0)
+	if typeName == "float32" {
+		return 4
+	}
 	if typeName == "int64" || typeName == "uint64" || typeName == "float64" {
 		return 8
 	}
@@ -541,6 +543,10 @@ func (c *Compiler) structFieldStorageSize(field *Node, pkgPath string) int {
 
 func (c *Compiler) emitZeroValueForTypeName(typeName string) {
 	typeName = c.resolveStorageTypeName(typeName, 0)
+	if typeName == "float32" {
+		c.emit(makeInst(ir.OP_CONST_F32, 0, 4, 0, "0.0"))
+		return
+	}
 	if typeName == "float64" {
 		c.emit(makeInst(ir.OP_CONST_F64, 0, 8, 0, "0.0"))
 		return
@@ -887,7 +893,7 @@ func (c *Compiler) resolveExprType(node *Node) string {
 	}
 	if node.Kind == NIdent {
 		if sym, ok := c.curPkg.Symbols[node.Name]; ok && sym.Kind == SymConst && sym.Node != nil && c.isConstFloatExpr(sym.Node.X) {
-			return "float64"
+			return c.exprConcreteType(sym.Node.X)
 		}
 		if ct, ok := c.localConcreteTypes[node.Name]; ok {
 			return ct
@@ -984,7 +990,7 @@ func (c *Compiler) resolveExprType(node *Node) string {
 		}
 		if node.X != nil && node.X.Kind == NIdent {
 			switch node.X.Name {
-			case "int", "uintptr", "uint", "byte", "int8", "uint8", "int16", "int32", "int64", "uint16", "uint32", "uint64", "float64":
+			case "int", "uintptr", "uint", "byte", "int8", "uint8", "int16", "int32", "int64", "uint16", "uint32", "uint64", "float32", "float64":
 				return node.X.Name
 			}
 		}
@@ -1139,7 +1145,7 @@ func isFloatTypeName(name string) bool {
 		}
 		i--
 	}
-	return name == "float64"
+	return name == "float32" || name == "float64"
 }
 
 // typeWidth returns the byte width for a named type.
@@ -1150,7 +1156,7 @@ func typeWidth(name string) int {
 		return 1
 	case "int16", "uint16":
 		return 2
-	case "int32", "uint32":
+	case "int32", "uint32", "float32":
 		return 4
 	case "int64", "uint64", "float64":
 		return 8
@@ -1169,6 +1175,12 @@ func (c *Compiler) setLocalTypeFlags(idx int, typeName string) {
 	}
 	c.curFunc.Locals[idx].Is64 = typeName == "uint64" || typeName == "int64"
 	c.curFunc.Locals[idx].IsFloat64 = typeName == "float64"
+	c.curFunc.Locals[idx].FloatKind = ir.TY_VOID
+	if typeName == "float32" {
+		c.curFunc.Locals[idx].FloatKind = ir.TY_FLOAT32
+	} else if typeName == "float64" {
+		c.curFunc.Locals[idx].FloatKind = ir.TY_FLOAT64
+	}
 }
 
 func (c *Compiler) resolveStorageTypeName(typeName string, depth int) string {
@@ -1256,6 +1268,8 @@ func (c *Compiler) irResultKindForTypeNode(node *Node) ir.TypeKind {
 		return ir.TY_INT32
 	case "int", "int64", "uint", "uint64":
 		return ir.TY_INT
+	case "float32":
+		return ir.TY_FLOAT32
 	case "float64":
 		return ir.TY_FLOAT64
 	case "uintptr":
@@ -1346,9 +1360,50 @@ func (c *Compiler) isFloatExpr(node *Node) bool {
 	return isFloatTypeName(typ)
 }
 
-func floatInstName(typeName string) string {
-	if isFloatTypeName(typeName) {
+func (c *Compiler) floatExprTypeName(node *Node) string {
+	if node == nil {
+		return ""
+	}
+	if node.Kind == NFloatLit {
+		// Untyped float literals default to float64 unless a surrounding typed
+		// context narrows them explicitly.
+		return ""
+	}
+	typ := c.resolveExprType(node)
+	if typ == "" {
+		typ = c.exprConcreteType(node)
+	}
+	return floatInstName(c.resolveStorageTypeName(typ, 0))
+}
+
+func mergeFloatTypeNames(left string, right string) string {
+	if left == "float64" || right == "float64" {
 		return "float64"
+	}
+	if left == "float32" || right == "float32" {
+		return "float32"
+	}
+	return "float64"
+}
+
+func floatInstName(typeName string) string {
+	typeName = strings.TrimSpace(typeName)
+	if typeName == "" {
+		return ""
+	}
+	for len(typeName) > 0 && typeName[0] == '*' {
+		typeName = typeName[1:]
+	}
+	i := len(typeName) - 1
+	for i >= 0 {
+		if typeName[i] == '.' {
+			typeName = typeName[i+1:]
+			break
+		}
+		i--
+	}
+	if typeName == "float32" || typeName == "float64" {
+		return typeName
 	}
 	return ""
 }
@@ -1357,9 +1412,46 @@ func (c *Compiler) floatInstNameForTypeName(typeName string) string {
 	return floatInstName(c.resolveStorageTypeName(typeName, 0))
 }
 
+func (c *Compiler) resolvedFloatInstName(node *Node) string {
+	return mergeFloatTypeNames(c.floatExprTypeName(node), "")
+}
+
+func (c *Compiler) convertSourceKind(node *Node) int64 {
+	if node == nil {
+		return ir.CONVERT_SRC_UNKNOWN
+	}
+	typeName := c.resolveExprType(node)
+	if typeName == "" {
+		typeName = c.exprConcreteType(node)
+	}
+	if typeName == "" && node.Kind == NFloatLit {
+		typeName = "float64"
+	}
+	switch c.resolveStorageTypeName(typeName, 0) {
+	case "float32":
+		return ir.CONVERT_SRC_FLOAT32
+	case "float64":
+		return ir.CONVERT_SRC_FLOAT64
+	case "uint", "uint8", "uint16", "uint32", "uint64", "uintptr", "byte":
+		return ir.CONVERT_SRC_UINT
+	case "bool", "int", "int8", "int16", "int32", "int64", "rune":
+		return ir.CONVERT_SRC_INT
+	default:
+		return ir.CONVERT_SRC_UNKNOWN
+	}
+}
+
+func (c *Compiler) emitConvertForExpr(node *Node, targetType string) {
+	c.emit(makeInst(ir.OP_CONVERT, 0, c.exprWidth(node), c.convertSourceKind(node), targetType))
+}
+
 func (c *Compiler) maybeConvertArgForParamType(arg *Node, paramType string) {
-	if isFloatTypeName(paramType) && !c.isFloatExpr(arg) {
-		c.emit(makeInst(ir.OP_CONVERT, 0, 0, 0, "float64"))
+	paramType = c.resolveStorageTypeName(paramType, 0)
+	if isFloatTypeName(paramType) {
+		argType := c.floatExprTypeName(arg)
+		if argType == "" || argType != paramType {
+			c.emitConvertForExpr(arg, paramType)
+		}
 	}
 }
 
@@ -1622,7 +1714,7 @@ func (c *Compiler) isConstFloatExpr(node *Node) bool {
 		return ok && sym.Kind == SymConst && sym.Node != nil && c.isConstFloatExpr(sym.Node.X)
 	case NCallExpr:
 		if node.X != nil && node.X.Kind == NIdent && len(node.Nodes) > 0 {
-			return node.X.Name == "float64" || c.isConstFloatExpr(node.Nodes[0])
+			return node.X.Name == "float32" || node.X.Name == "float64" || c.isConstFloatExpr(node.Nodes[0])
 		}
 	}
 	return false
@@ -3852,7 +3944,7 @@ func (c *Compiler) resolvedCallRetCount(callName string) int {
 
 func (c *Compiler) instStackDelta(inst ir.Inst) int {
 	switch inst.Op {
-	case ir.OP_CONST_I64, ir.OP_CONST_F64, ir.OP_CONST_STR, ir.OP_CONST_BOOL, ir.OP_CONST_NIL:
+	case ir.OP_CONST_I64, ir.OP_CONST_F32, ir.OP_CONST_F64, ir.OP_CONST_STR, ir.OP_CONST_BOOL, ir.OP_CONST_NIL:
 		return 1
 	case ir.OP_LOCAL_GET, ir.OP_GLOBAL_GET, ir.OP_LOCAL_ADDR, ir.OP_GLOBAL_ADDR:
 		return 1
@@ -4332,10 +4424,19 @@ func (c *Compiler) compileCompoundAssign(node *Node, op ir.Opcode) {
 		c.strictCheckPointerArithmetic("+", node.X, node.Y)
 	}
 	w := c.exprWidth(node.X)
+	floatType := c.floatInstNameForTypeName(c.resolveExprType(node.X))
 	c.compileLValueGet(node.X)
 	c.compileExpr(node.Y)
+	if floatType != "" {
+		rhsFloatType := c.floatExprTypeName(node.Y)
+		if rhsFloatType == "" || rhsFloatType != floatType {
+			c.emitConvertForExpr(node.Y, floatType)
+		}
+	}
 	inst := ir.Inst{Op: op, Width: w}
-	if (op == ir.OP_ADD || op == ir.OP_SUB || op == ir.OP_MUL || op == ir.OP_SHR || op == ir.OP_DIV || op == ir.OP_MOD) && c.isUnsignedExpr(node.X) {
+	if floatType != "" {
+		inst.Name = floatType
+	} else if (op == ir.OP_ADD || op == ir.OP_SUB || op == ir.OP_MUL || op == ir.OP_SHR || op == ir.OP_DIV || op == ir.OP_MOD) && c.isUnsignedExpr(node.X) {
 		inst.Name = "unsigned"
 	}
 	c.emit(inst)
@@ -4466,6 +4567,9 @@ func (c *Compiler) compileVarDecl(node *Node) {
 				c.maybeBoxValueForInterface(node.X)
 			}
 		}
+		if node.Type != nil {
+			c.maybeConvertArgForParamType(node.X, nodeTypeName(node.Type))
+		}
 		c.emit(ir.Inst{Op: ir.OP_LOCAL_SET, Arg: idx, Width: c.curFunc.Locals[idx].Width})
 	} else {
 		// Fixed-size arrays are represented as slice-header handles with a fixed
@@ -4504,8 +4608,12 @@ func (c *Compiler) compileVarDecl(node *Node) {
 				return
 			}
 		}
-		// Zero-initialize the local to avoid stack garbage
-		c.emit(ir.Inst{Op: ir.OP_CONST_I64, Val: 0})
+		// Zero-initialize the local to avoid stack garbage.
+		if node.Type != nil {
+			c.emitZeroValueForTypeName(nodeTypeName(node.Type))
+		} else {
+			c.emit(ir.Inst{Op: ir.OP_CONST_I64, Val: 0})
+		}
 		c.emit(ir.Inst{Op: ir.OP_LOCAL_SET, Arg: idx})
 	}
 }
@@ -4515,7 +4623,7 @@ func isBuiltinTypeName(t string) bool {
 	case "bool",
 		"int", "int8", "int16", "int32", "int64",
 		"uint", "uint8", "uint16", "uint32", "uint64",
-		"float64",
+		"float32", "float64",
 		"uintptr", "byte", "rune",
 		"string", "error", "interface{}":
 		return true
@@ -4603,10 +4711,7 @@ func (c *Compiler) compileAssign(node *Node) {
 						c.localTypes[lhsName] = assertedType
 					}
 					if idx, ok := c.lookupLocal(lhsName); ok {
-						storageType := c.resolveStorageTypeName(assertedType, 0)
-						c.curFunc.Locals[idx].Width = c.storageSizeForTypeName(assertedType)
-						c.curFunc.Locals[idx].Is64 = storageType == "int64" || storageType == "uint64"
-						c.curFunc.Locals[idx].IsFloat64 = storageType == "float64"
+						c.setLocalTypeFlags(idx, assertedType)
 					}
 					if elemType, ok := splitBracketType(assertedType); ok {
 						c.localElemSizes[lhsName] = c.typeElemSize(elemType)
@@ -4689,8 +4794,16 @@ func (c *Compiler) compileAssign(node *Node) {
 		if w != 0 {
 			c.curFunc.Locals[idx].Width = w
 			c.curFunc.Locals[idx].Is64 = false
-			c.curFunc.Locals[idx].IsFloat64 = c.isFloatExpr(node.Y)
-			if w == 8 && !c.curFunc.Locals[idx].IsFloat64 {
+			c.curFunc.Locals[idx].IsFloat64 = false
+			c.curFunc.Locals[idx].FloatKind = ir.TY_VOID
+			switch c.resolvedFloatInstName(node.Y) {
+			case "float32":
+				c.curFunc.Locals[idx].FloatKind = ir.TY_FLOAT32
+			case "float64":
+				c.curFunc.Locals[idx].FloatKind = ir.TY_FLOAT64
+				c.curFunc.Locals[idx].IsFloat64 = true
+			}
+			if w == 8 && c.curFunc.Locals[idx].FloatKind == ir.TY_VOID {
 				c.curFunc.Locals[idx].Is64 = true
 			}
 		}
@@ -4788,6 +4901,9 @@ func (c *Compiler) compileAssign(node *Node) {
 			return
 		}
 		c.compileExpr(node.Y)
+		if lhsType := c.resolveExprType(node.X); isFloatTypeName(lhsType) {
+			c.maybeConvertArgForParamType(node.Y, lhsType)
+		}
 		if ct, ok := c.localConcreteTypes[node.X.Name]; ok {
 			c.maybeCloneArrayForTypeName(ct)
 		}
@@ -4836,6 +4952,9 @@ func (c *Compiler) compileAssign(node *Node) {
 		c.compileExpr(node.X.X) // push map
 		c.compileExpr(node.X.Y) // push key
 		c.compileExpr(node.Y)   // push value
+		if isFloatTypeName(mapValueTypeQualified) || isFloatTypeName(mapValueType) {
+			c.maybeConvertArgForParamType(node.Y, mapValueTypeQualified)
+		}
 		if mapValueIsInterface {
 			c.maybeBoxValueForInterface(node.Y)
 		}
@@ -4850,6 +4969,9 @@ func (c *Compiler) compileAssign(node *Node) {
 		return
 	}
 	c.compileExpr(node.Y)
+	if lhsType := c.resolveExprType(node.X); isFloatTypeName(lhsType) {
+		c.maybeConvertArgForParamType(node.Y, lhsType)
+	}
 	if _, ok := c.lvalueInterfaceType(node.X); ok {
 		c.maybeBoxValueForInterface(node.Y)
 	}
@@ -5866,7 +5988,7 @@ func (c *Compiler) exprConcreteType(expr *Node) string {
 		}
 		if expr.X != nil && expr.X.Kind == NIdent {
 			switch expr.X.Name {
-			case "int", "uintptr", "uint", "byte", "int8", "uint8", "int16", "int32", "int64", "uint16", "uint32", "uint64", "float64":
+			case "int", "uintptr", "uint", "byte", "int8", "uint8", "int16", "int32", "int64", "uint16", "uint32", "uint64", "float32", "float64":
 				return expr.X.Name
 			}
 		}
@@ -5926,7 +6048,7 @@ func (c *Compiler) exprConcreteType(expr *Node) string {
 	// Variable reference: check localConcreteTypes
 	if expr.Kind == NIdent {
 		if sym, ok := c.curPkg.Symbols[expr.Name]; ok && sym.Kind == SymConst && sym.Node != nil && c.isConstFloatExpr(sym.Node.X) {
-			return "float64"
+			return c.exprConcreteType(sym.Node.X)
 		}
 		if ct, ok := c.localConcreteTypes[expr.Name]; ok {
 			return ct
@@ -6072,6 +6194,10 @@ func (c *Compiler) invertCmpOp(op string) string {
 func (c *Compiler) emitCmpJump(op string, node *Node, targetLabel int) bool {
 	var irOp ir.Opcode
 	isFloat := c.isFloatExpr(node.X) || c.isFloatExpr(node.Y)
+	floatType := ""
+	if isFloat {
+		floatType = mergeFloatTypeNames(c.floatExprTypeName(node.X), c.floatExprTypeName(node.Y))
+	}
 	switch op {
 	case "==":
 		irOp = ir.OP_JMP_EQ
@@ -6089,16 +6215,22 @@ func (c *Compiler) emitCmpJump(op string, node *Node, targetLabel int) bool {
 		return false
 	}
 	c.compileExpr(node.X)
-	if isFloat && !c.isFloatExpr(node.X) {
-		c.emit(makeInst(ir.OP_CONVERT, 0, 0, 0, "float64"))
+	if floatType != "" {
+		leftFloatType := c.floatExprTypeName(node.X)
+		if leftFloatType == "" || leftFloatType != floatType {
+			c.emitConvertForExpr(node.X, floatType)
+		}
 	}
 	c.compileExpr(node.Y)
-	if isFloat && !c.isFloatExpr(node.Y) {
-		c.emit(makeInst(ir.OP_CONVERT, 0, 0, 0, "float64"))
+	if floatType != "" {
+		rightFloatType := c.floatExprTypeName(node.Y)
+		if rightFloatType == "" || rightFloatType != floatType {
+			c.emitConvertForExpr(node.Y, floatType)
+		}
 	}
 	inst := ir.Inst{Op: irOp, Arg: targetLabel, Width: c.exprWidth(node)}
-	if isFloat {
-		inst.Name = "float64"
+	if floatType != "" {
+		inst.Name = floatType
 	} else if c.isUnsignedComparison(node) {
 		inst.Name = "unsigned"
 	}
@@ -6693,10 +6825,8 @@ func (c *Compiler) compileTypeAssert(node *Node, commaOk bool) {
 		ifaceIdx := c.addLocal("$typeassert_iface")
 		valIdx := c.addLocal("$typeassert_val")
 		okIdx := c.addLocal("$typeassert_ok")
-		storageType := c.resolveStorageTypeName(assertedType, 0)
+		c.setLocalTypeFlags(valIdx, assertedType)
 		c.curFunc.Locals[valIdx].Width = payloadSize
-		c.curFunc.Locals[valIdx].Is64 = storageType == "int64" || storageType == "uint64"
-		c.curFunc.Locals[valIdx].IsFloat64 = storageType == "float64"
 
 		c.compileExpr(node.X)
 		c.emit(ir.Inst{Op: ir.OP_LOCAL_SET, Arg: ifaceIdx})
@@ -6734,10 +6864,8 @@ func (c *Compiler) compileTypeAssert(node *Node, commaOk bool) {
 
 	ifaceIdx := c.addLocal("$typeassert_iface")
 	valIdx := c.addLocal("$typeassert_val")
-	storageType := c.resolveStorageTypeName(assertedType, 0)
+	c.setLocalTypeFlags(valIdx, assertedType)
 	c.curFunc.Locals[valIdx].Width = payloadSize
-	c.curFunc.Locals[valIdx].Is64 = storageType == "int64" || storageType == "uint64"
-	c.curFunc.Locals[valIdx].IsFloat64 = storageType == "float64"
 
 	c.compileExpr(node.X)
 	c.emit(ir.Inst{Op: ir.OP_LOCAL_SET, Arg: ifaceIdx})
@@ -7384,11 +7512,15 @@ func (c *Compiler) compileBinaryExpr(node *Node) {
 		return
 	}
 	isFloat := c.isFloatExpr(node.X) || c.isFloatExpr(node.Y)
+	floatType := ""
+	if isFloat {
+		floatType = mergeFloatTypeNames(c.floatExprTypeName(node.X), c.floatExprTypeName(node.Y))
+	}
 	if isFloat {
 		switch node.Name {
 		case "%", "&", "|", "^", "<<", ">>":
-			c.errorf("%s: operator %s is not supported for float64", c.curFunc.Name, node.Name)
-			c.emit(makeInst(ir.OP_CONST_F64, 0, 8, 0, "0.0"))
+			c.errorf("%s: operator %s is not supported for %s", c.curFunc.Name, node.Name, floatType)
+			c.emitZeroValueForTypeName(floatType)
 			return
 		}
 	}
@@ -7409,7 +7541,19 @@ func (c *Compiler) compileBinaryExpr(node *Node) {
 	}
 
 	c.compileExpr(node.X)
+	if floatType != "" {
+		leftFloatType := c.floatExprTypeName(node.X)
+		if leftFloatType == "" || leftFloatType != floatType {
+			c.emitConvertForExpr(node.X, floatType)
+		}
+	}
 	c.compileExpr(node.Y)
+	if floatType != "" {
+		rightFloatType := c.floatExprTypeName(node.Y)
+		if rightFloatType == "" || rightFloatType != floatType {
+			c.emitConvertForExpr(node.Y, floatType)
+		}
+	}
 
 	w := c.exprWidth(node)
 
@@ -7417,7 +7561,7 @@ func (c *Compiler) compileBinaryExpr(node *Node) {
 	case "+":
 		inst := ir.Inst{Op: ir.OP_ADD, Width: w}
 		if isFloat {
-			inst.Name = "float64"
+			inst.Name = floatType
 		} else if c.isUnsignedExpr(node.X) {
 			inst.Name = "unsigned"
 		}
@@ -7425,7 +7569,7 @@ func (c *Compiler) compileBinaryExpr(node *Node) {
 	case "-":
 		inst := ir.Inst{Op: ir.OP_SUB, Width: w}
 		if isFloat {
-			inst.Name = "float64"
+			inst.Name = floatType
 		} else if c.isUnsignedExpr(node.X) {
 			inst.Name = "unsigned"
 		}
@@ -7433,7 +7577,7 @@ func (c *Compiler) compileBinaryExpr(node *Node) {
 	case "*":
 		inst := ir.Inst{Op: ir.OP_MUL, Width: w}
 		if isFloat {
-			inst.Name = "float64"
+			inst.Name = floatType
 		} else if c.isUnsignedExpr(node.X) {
 			inst.Name = "unsigned"
 		}
@@ -7441,7 +7585,7 @@ func (c *Compiler) compileBinaryExpr(node *Node) {
 	case "/":
 		inst := ir.Inst{Op: ir.OP_DIV, Width: w}
 		if isFloat {
-			inst.Name = "float64"
+			inst.Name = floatType
 		} else if c.isUnsignedExpr(node.X) {
 			inst.Name = "unsigned"
 		}
@@ -7469,7 +7613,7 @@ func (c *Compiler) compileBinaryExpr(node *Node) {
 	case "==":
 		inst := ir.Inst{Op: ir.OP_EQ, Width: w}
 		if isFloat {
-			inst.Name = "float64"
+			inst.Name = floatType
 		} else if c.isUnsignedComparison(node) {
 			inst.Name = "unsigned"
 		}
@@ -7477,7 +7621,7 @@ func (c *Compiler) compileBinaryExpr(node *Node) {
 	case "!=":
 		inst := ir.Inst{Op: ir.OP_NEQ, Width: w}
 		if isFloat {
-			inst.Name = "float64"
+			inst.Name = floatType
 		} else if c.isUnsignedComparison(node) {
 			inst.Name = "unsigned"
 		}
@@ -7485,7 +7629,7 @@ func (c *Compiler) compileBinaryExpr(node *Node) {
 	case "<":
 		inst := ir.Inst{Op: ir.OP_LT, Width: w}
 		if isFloat {
-			inst.Name = "float64"
+			inst.Name = floatType
 		} else if c.isUnsignedComparison(node) {
 			inst.Name = "unsigned"
 		}
@@ -7493,7 +7637,7 @@ func (c *Compiler) compileBinaryExpr(node *Node) {
 	case ">":
 		inst := ir.Inst{Op: ir.OP_GT, Width: w}
 		if isFloat {
-			inst.Name = "float64"
+			inst.Name = floatType
 		} else if c.isUnsignedComparison(node) {
 			inst.Name = "unsigned"
 		}
@@ -7501,7 +7645,7 @@ func (c *Compiler) compileBinaryExpr(node *Node) {
 	case "<=":
 		inst := ir.Inst{Op: ir.OP_LEQ, Width: w}
 		if isFloat {
-			inst.Name = "float64"
+			inst.Name = floatType
 		} else if c.isUnsignedComparison(node) {
 			inst.Name = "unsigned"
 		}
@@ -7509,7 +7653,7 @@ func (c *Compiler) compileBinaryExpr(node *Node) {
 	case ">=":
 		inst := ir.Inst{Op: ir.OP_GEQ, Width: w}
 		if isFloat {
-			inst.Name = "float64"
+			inst.Name = floatType
 		} else if c.isUnsignedComparison(node) {
 			inst.Name = "unsigned"
 		}
@@ -7529,7 +7673,7 @@ func (c *Compiler) compileUnaryExpr(node *Node) {
 		c.compileExpr(node.X)
 		inst := makeInst(ir.OP_NEG, 0, w, 0, "")
 		if c.isFloatExpr(node.X) {
-			inst.Name = "float64"
+			inst.Name = c.resolvedFloatInstName(node.X)
 		}
 		c.emit(inst)
 	case "*":
@@ -7546,8 +7690,9 @@ func (c *Compiler) compileUnaryExpr(node *Node) {
 		c.compileAddrOf(node.X)
 	case "^":
 		if c.isFloatExpr(node.X) {
-			c.errorf("%s: operator ^ is not supported for float64", c.curFunc.Name)
-			c.emit(makeInst(ir.OP_CONST_F64, 0, 8, 0, "0.0"))
+			floatType := c.resolvedFloatInstName(node.X)
+			c.errorf("%s: operator ^ is not supported for %s", c.curFunc.Name, floatType)
+			c.emitZeroValueForTypeName(floatType)
 			return
 		}
 		w := c.exprWidth(node.X)
@@ -7636,7 +7781,7 @@ func (c *Compiler) isPointerToStructDeref(node *Node) bool {
 	if pointeeType == "int" || pointeeType == "int16" || pointeeType == "int32" || pointeeType == "int64" ||
 		pointeeType == "uint" || pointeeType == "uint16" || pointeeType == "uint32" || pointeeType == "uint64" ||
 		pointeeType == "uintptr" || pointeeType == "byte" || pointeeType == "bool" || pointeeType == "string" ||
-		pointeeType == "float64" {
+		pointeeType == "float32" || pointeeType == "float64" {
 		return false
 	}
 	typeNode, _ := c.lookupStructTypeNode(pointeeType)
@@ -8690,11 +8835,6 @@ func (c *Compiler) compileCallExpr(node *Node) {
 			c.emit(ir.Inst{Op: ir.OP_CONST_NIL})
 			return
 		}
-		if name == "float32" {
-			c.errorf("%s: %s conversion is not supported (floating-point support is not implemented)", c.curFunc.Name, name)
-			c.emit(ir.Inst{Op: ir.OP_CONST_NIL})
-			return
-		}
 		if name == "len" {
 			if len(node.Nodes) != 1 {
 				c.errorf("%s: len expects exactly one argument", c.curFunc.Name)
@@ -8832,14 +8972,14 @@ func (c *Compiler) compileCallExpr(node *Node) {
 			return
 		}
 		// Type conversions: int(), uintptr(), byte(), string(), int16(), int32()
-		if name == "int" || name == "uintptr" || name == "uint" || name == "byte" || name == "int8" || name == "uint8" || name == "string" || name == "int16" || name == "int32" || name == "int64" || name == "uint16" || name == "uint32" || name == "uint64" || name == "float64" {
+		if name == "int" || name == "uintptr" || name == "uint" || name == "byte" || name == "int8" || name == "uint8" || name == "string" || name == "int16" || name == "int32" || name == "int64" || name == "uint16" || name == "uint32" || name == "uint64" || name == "float32" || name == "float64" {
 			arg := node.Nodes[0]
 			c.compileExpr(arg)
 			if name == "string" {
 				if c.isExprByte(arg) {
 					c.emitKnownCall("runtime.ByteToString", 1, 1)
 				} else if c.isExprByteSlice(arg) {
-					c.emit(makeInst(ir.OP_CONVERT, 0, 0, 0, name))
+					c.emitConvertForExpr(arg, name)
 				} else if c.isStringTypedExpr(arg) {
 					// string(string) is a no-op.
 				} else if c.isExprIntegerLike(arg) {
@@ -8847,10 +8987,10 @@ func (c *Compiler) compileCallExpr(node *Node) {
 					c.emitKnownCall("runtime.RuneToString", 1, 1)
 				} else {
 					// Prefer slice->string semantics unless we know this is integer-like.
-					c.emit(makeInst(ir.OP_CONVERT, 0, 0, 0, name))
+					c.emitConvertForExpr(arg, name)
 				}
 			} else {
-				c.emit(makeInst(ir.OP_CONVERT, 0, 0, 0, name))
+				c.emitConvertForExpr(arg, name)
 			}
 			return
 		}
@@ -8867,7 +9007,11 @@ func (c *Compiler) compileCallExpr(node *Node) {
 	if node.X != nil && node.X.Kind == NIdent && len(node.Nodes) == 1 {
 		if _, ok := c.lookupCurrentTypeDecl(node.X.Name); ok {
 			c.compileExpr(node.Nodes[0])
-			c.emit(makeInst(ir.OP_CONVERT, 0, 0, 0, node.X.Name))
+			targetType := c.resolveStorageTypeName(node.X.Name, 0)
+			if targetType == "" {
+				targetType = node.X.Name
+			}
+			c.emitConvertForExpr(node.Nodes[0], targetType)
 			return
 		}
 	}
@@ -8880,7 +9024,11 @@ func (c *Compiler) compileCallExpr(node *Node) {
 		if impPkg != nil {
 			if sym, ok := impPkg.Symbols[typeName]; ok && sym.Kind == SymType {
 				c.compileExpr(node.Nodes[0])
-				c.emit(makeInst(ir.OP_CONVERT, 0, 0, 0, typeName))
+				targetType := c.resolveStorageTypeName(impPkg.QualName(typeName), 0)
+				if targetType == "" {
+					targetType = typeName
+				}
+				c.emitConvertForExpr(node.Nodes[0], targetType)
 				return
 			}
 		}
@@ -10595,7 +10743,7 @@ func isDefinitelyScalarTypeName(t string) bool {
 	case "bool",
 		"int", "int16", "int32", "int64",
 		"uint", "uint16", "uint32", "uint64",
-		"uintptr", "byte", "rune", "float64":
+		"uintptr", "byte", "rune", "float32", "float64":
 		return true
 	}
 	return false

--- a/std/compiler/frontend/go/compiler.go
+++ b/std/compiler/frontend/go/compiler.go
@@ -1426,7 +1426,16 @@ func (c *Compiler) floatInstNameForTypeName(typeName string) string {
 }
 
 func (c *Compiler) resolvedFloatInstName(node *Node) string {
-	return mergeFloatTypeNames(c.floatExprTypeName(node), "")
+	if node == nil {
+		return ""
+	}
+	if typ := c.floatExprTypeName(node); typ != "" {
+		return typ
+	}
+	if c.isConstFloatExpr(node) {
+		return "float64"
+	}
+	return ""
 }
 
 func (c *Compiler) convertSourceKind(node *Node) int64 {

--- a/std/compiler/frontend/go/parser.go
+++ b/std/compiler/frontend/go/parser.go
@@ -1184,7 +1184,7 @@ func (p *Parser) parseType() *Node {
 		if tok.Val == "any" {
 			return &Node{Kind: NIdent, Name: "interface{}", Pos: tok.Line}
 		}
-		if tok.Val == "float32" || tok.Val == "complex64" || tok.Val == "complex128" {
+		if tok.Val == "complex64" || tok.Val == "complex128" {
 			p.errorf("%s type is not supported at line %d", tok.Val, tok.Line)
 			return &Node{Kind: NIdent, Name: "error", Pos: tok.Line}
 		}

--- a/std/compiler/ir/irtypes.go
+++ b/std/compiler/ir/irtypes.go
@@ -11,6 +11,7 @@ const (
 	TY_BYTE
 	TY_INT32
 	TY_INT
+	TY_FLOAT32
 	TY_FLOAT64
 	TY_UINTPTR
 	TY_STRING
@@ -50,6 +51,7 @@ type Opcode int
 
 const (
 	OP_CONST_I64 Opcode = iota
+	OP_CONST_F32
 	OP_CONST_F64
 	OP_CONST_STR
 	OP_CONST_BOOL
@@ -122,6 +124,14 @@ const (
 	OP_CAP
 )
 
+const (
+	CONVERT_SRC_UNKNOWN = iota
+	CONVERT_SRC_INT
+	CONVERT_SRC_UINT
+	CONVERT_SRC_FLOAT32
+	CONVERT_SRC_FLOAT64
+)
+
 // Inst annotation names used by backend-independent optimization passes.
 const (
 	// InstNonNilMemoryBase marks LOAD/LEN/CAP instructions whose pointer input
@@ -163,7 +173,8 @@ type IRLocal struct {
 	Index     int
 	Is64      bool // true for uint64/int64 locals (need i64 on wasm32)
 	IsFloat64 bool // true for float64 locals (need f64 on wasm32)
-	Width     int  // storage width: 0=word, 1=byte, 2=int16, 4=int32, 8=int64/float64
+	FloatKind TypeKind
+	Width     int // storage width: 0=word, 1=byte, 2=int16, 4=int32, 8=int64/float64
 }
 
 // IRFunc represents a compiled function.


### PR DESCRIPTION
## Summary
- add `float32` IR/frontend support alongside the existing `float64` work
- teach the IR text/binary codecs and IR printer about `TY_FLOAT32`, `OP_CONST_F32`, and float local metadata
- add scalar `float32`/`float64` lowering for the C backend using raw-bit transport in `rtg_word`, including float arithmetic, compares, jumps, conversions, and sized load/store fixes
- document the current C-profile limitation: `float64` requires `c/64`, and `float32` requires at least `c/32`

## Validation
- `./build/build build`
- `./build/rtg -T ir -o - tmp/float_smoke.go`
- `./build/rtg -T c/64 tmp/float_smoke.go -o tmp/float_smoke.c`
- `cc -O0 tmp/float_smoke.c -o tmp/float_smoke.bin`
- `./tmp/float_smoke.bin`
- `./build/build test-fullcompiler-c`
- `./build/build selfhost-c`
